### PR TITLE
Generate xml defs

### DIFF
--- a/ubx/messages.xml
+++ b/ubx/messages.xml
@@ -1,0 +1,23859 @@
+<?xml version='1.0' encoding='utf-8'?>
+<definitions>
+  <message>
+    <name>UBX-ACK-ACK</name>
+    <type>Output</type>
+    <description>Message acknowledged</description>
+    <comment>Output upon processing of an input message. A UBX-ACK-ACK is sent as soon as possible but at least within one second.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x05</class>
+      <id>0x01</id>
+      <length>2</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>clsID</name>
+          <type>U1</type>
+          <comment>Class ID of the Acknowledged Message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>msgID</name>
+          <type>U1</type>
+          <comment>Message ID of the Acknowledged
+Message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-ACK-NAK</name>
+    <type>Output</type>
+    <description>Message not acknowledged</description>
+    <comment>Output upon processing of an input message. A UBX-ACK-NAK is sent as soon as possible but at least within one second.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x05</class>
+      <id>0x00</id>
+      <length>2</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>clsID</name>
+          <type>U1</type>
+          <comment>Class ID of the Not-Acknowledged
+Message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>msgID</name>
+          <type>U1</type>
+          <comment>Message ID of the Not-Acknowledged
+Message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-ALM</name>
+    <type>Poll Request</type>
+    <description>Poll GPS aiding almanac data</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead Poll GPS aiding data (Almanac) for all 32 SVs by sending this message to the receiver without any payload. The receiver will return 32 messages of type AID- ALM as defined below.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x30</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-ALM</name>
+    <type>Poll Request</type>
+    <description>Poll GPS aiding almanac data for a SV</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead Poll GPS aiding data (Almanac) for an SV by sending this message to the receiver. The receiver will return one message of type AID-ALM as defined below.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x30</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>svid</name>
+          <type>U1</type>
+          <comment>SV ID for which the receiver shall return its
+Almanac Data (Valid Range: 1 .. 32 or 51,
+56, 63).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-ALM</name>
+    <type>Input/Output</type>
+    <description>GPS aiding almanac input/output message</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead  If the WEEK Value is 0, DWRD0 to DWRD7 are not sent as the Almanac is not  available for the given SV. This may happen even if NAV-SVINFO and RXM-  SVSI are indicating almanac availability as the internal data may not represent  the content of an original broadcast almanac (or only parts thereof).  DWORD0 to DWORD7 contain the 8 words following the Hand-Over Word (  HOW ) from the GPS navigation message, either pages 1 to 24 of sub-frame 5 or  pages 2 to 10 of subframe 4. See IS-GPS-200 for a full description of the  contents of the Almanac pages.  In DWORD0 to DWORD7, the parity bits have been removed, and the 24 bits of  data are located in Bits 0 to 23. Bits 24 to 31 shall be ignored.  Example: Parameter e (Eccentricity) from Almanac Subframe 4/5, Word 3, Bits  69-84 within the subframe can be found in DWRD0, Bits 15-0 whereas Bit 0 is  the LSB.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x30</id>
+      <length>(8) or (40)</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>svid</name>
+          <type>U4</type>
+          <comment>SV ID for which this
+Almanac Data is (Valid Range: 1 .. 32 or 51,
+56, 63).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>week</name>
+          <type>U4</type>
+          <comment>Issue Date of Almanac (GPS week number)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block type="optional">
+          <block>
+            <offset>8</offset>
+            <name>dwrd</name>
+            <type>U4[8]</type>
+            <comment>Almanac Words</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-AOP</name>
+    <type>Poll Request</type>
+    <description>Poll AssistNow Autonomous data, all satellites</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead Poll AssistNow Autonomous aiding data for all GPS satellites by sending this empty message. The receiver will return an AID-AOP message (see definition below) for each GPS satellite for which data is available.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x33</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-AOP</name>
+    <type>Poll Request</type>
+    <description>Poll AssistNow Autonomous data, one GPS satellite</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead Poll the AssistNow Autonomous data for the specified GPS satellite. The receiver will return a AID-AOP message (see definition below) if data is available for the requested satellite.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x33</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>svid</name>
+          <type>U1</type>
+          <comment>GPS SV ID for which the data is requested
+(valid range: 1..32).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-AOP</name>
+    <type>Input/Output</type>
+    <description>AssistNow Autonomous data</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead If enabled, this message is output at irregular intervals. It is output whenever AssistNow Autonomous has produced new data for a satellite. Depending on the availability of the optional data the receiver will output either version of the message. If this message is polled using one of the two poll requests described above the receiver will send this message if AssistNow Autonomous data is available or the corresponding poll request message if no AssistNow Autonomous data is available for each satellite (i.e. svid 1..32). At the user's choice the optional data may be chopped from the payload of a previously polled message when sending the message back to the receiver. Sending a valid AID- AOP message to the receiver will automatically enable the AssistNow Autonomous feature on the receiver. See the section AssistNow Autonomous in the receiver description for details on this feature.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x33</id>
+      <length>68</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>gnssId</name>
+          <type>U1</type>
+          <comment>GNSS identifier (see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>data</name>
+          <type>U1[64]</type>
+          <comment>assistance data</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-EPH</name>
+    <type>Poll Request</type>
+    <description>Poll GPS aiding ephemeris data</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead Poll GPS Aiding Data (Ephemeris) for all 32 SVs by sending this message to the receiver without any payload. The receiver will return 32 messages of type AID- EPH as defined below.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x31</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-EPH</name>
+    <type>Poll Request</type>
+    <description>Poll GPS aiding ephemeris data for a SV</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead Poll GPS Constellation Data (Ephemeris) for an SV by sending this message to the receiver. The receiver will return one message of type AID-EPH as defined below.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x31</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>svid</name>
+          <type>U1</type>
+          <comment>SV ID for which the receiver shall return its
+Ephemeris Data (Valid Range: 1 .. 32).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-EPH</name>
+    <type>Input/Output</type>
+    <description>GPS aiding ephemeris input/output message</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead  SF1D0 to SF3D7 is only sent if ephemeris is available for this SV. If not, the  payload may be reduced to 8 Bytes, or all bytes are set to zero, indicating that  this SV Number does not have valid ephemeris for the moment. This may  happen even if NAV-SVINFO and RXM-SVSI are indicating ephemeris  availability as the internal data may not represent the content of an original  broadcast ephemeris (or only parts thereof).  SF1D0 to SF3D7 contain the 24 words following the Hand-Over Word ( HOW )  from the GPS navigation message, subframes 1 to 3. The Truncated TOW  Count is not valid and cannot be used. See IS-GPS-200 for a full description of  the contents of the Subframes.  In SF1D0 to SF3D7, the parity bits have been removed, and the 24 bits of data  are located in Bits 0 to 23. Bits 24 to 31 shall be ignored.  When polled, the data contained in this message does not represent the full  original ephemeris broadcast. Some fields that are irrelevant to u-blox receivers  may be missing. The week number in Subframe 1 has already been modified to  match the Time Of Ephemeris (TOE).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x31</id>
+      <length>(8) or (104)</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>svid</name>
+          <type>U4</type>
+          <comment>SV ID for which this ephemeris data is
+(Valid Range: 1 .. 32).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>how</name>
+          <type>U4</type>
+          <comment>Hand-Over Word of first Subframe. This is
+required if data is sent to the receiver.
+0 indicates that no Ephemeris Data is
+following.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block type="optional">
+          <block>
+            <offset>8</offset>
+            <name>sf1d</name>
+            <type>U4[8]</type>
+            <comment>Subframe 1 Words 3..10 (SF1D0..SF1D7)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>40</offset>
+            <name>sf2d</name>
+            <type>U4[8]</type>
+            <comment>Subframe 2 Words 3..10 (SF2D0..SF2D7)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>72</offset>
+            <name>sf3d</name>
+            <type>U4[8]</type>
+            <comment>Subframe 3 Words 3..10 (SF3D0..SF3D7)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-HUI</name>
+    <type>Poll Request</type>
+    <description>Poll GPS health, UTC, ionosphere parameters</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x02</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-HUI</name>
+    <type>Input/Output</type>
+    <description>GPS health, UTC and ionosphere parameters</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead This message contains a health bit mask, UTC time and Klobuchar parameters. For more information on these parameters, see the ICD-GPS-200 documentation.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x02</id>
+      <length>72</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>health</name>
+          <type>X4</type>
+          <comment>Bitmask, every bit represenst a GPS SV (1-
+32). If the bit is set the SV is healthy.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>utcA0</name>
+          <type>R8</type>
+          <comment>UTC - parameter A0</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>utcA1</name>
+          <type>R8</type>
+          <comment>UTC - parameter A1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>utcTOW</name>
+          <type>I4</type>
+          <comment>UTC - reference time of week</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>utcWNT</name>
+          <type>I2</type>
+          <comment>UTC - reference week number</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>utcLS</name>
+          <type>I2</type>
+          <comment>UTC - time difference due to leap seconds
+before event</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>utcWNF</name>
+          <type>I2</type>
+          <comment>UTC - week number when next leap
+second event occurs</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>utcDN</name>
+          <type>I2</type>
+          <comment>UTC - day of week when next leap second
+event occurs</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>utcLSF</name>
+          <type>I2</type>
+          <comment>UTC - time difference due to leap seconds
+after event</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>34</offset>
+          <name>utcSpare</name>
+          <type>I2</type>
+          <comment>UTC - Spare to ensure structure is a
+multiple of 4 bytes</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>klobA0</name>
+          <type>R4</type>
+          <comment>Klobuchar - alpha 0</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>klobA1</name>
+          <type>R4</type>
+          <comment>Klobuchar - alpha 1</comment>
+          <scale>-</scale>
+          <unit>s/semicircle</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>klobA2</name>
+          <type>R4</type>
+          <comment>Klobuchar - alpha 2</comment>
+          <scale>-</scale>
+          <unit>s/semicircle^2</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>klobA3</name>
+          <type>R4</type>
+          <comment>Klobuchar - alpha 3</comment>
+          <scale>-</scale>
+          <unit>s/semicircle^3</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>klobB0</name>
+          <type>R4</type>
+          <comment>Klobuchar - beta 0</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>klobB1</name>
+          <type>R4</type>
+          <comment>Klobuchar - beta 1</comment>
+          <scale>-</scale>
+          <unit>s/semicircle</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>klobB2</name>
+          <type>R4</type>
+          <comment>Klobuchar - beta 2</comment>
+          <scale>-</scale>
+          <unit>s/semicircle^2</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>klobB3</name>
+          <type>R4</type>
+          <comment>Klobuchar - beta 3</comment>
+          <scale>-</scale>
+          <unit>s/semicircle^3</unit>
+        </block>
+        <block>
+          <offset>68</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>healthValid</name>
+              <description>Healthmask field in this message is valid</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>utcValid</name>
+              <description>UTC parameter fields in this message are valid</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>klobValid</name>
+              <description>Klobuchar parameter fields in this message are valid</description>
+            </type>
+            <type>
+              <index>3:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-INI</name>
+    <type>Poll Request</type>
+    <description>Poll GPS initial aiding data</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x01</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-AID-INI</name>
+    <type>Input/Output</type>
+    <description>Aiding position, time, frequency, clock drift</description>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead This message contains position, time and clock drift information. The position can be input in either the ECEF X/Y/Z coordinate system or as lat/lon/height. The time can either be input as inexact value via the standard communication interface, suffering from latency depending on the baud rate, or using hardware time synchronization where an accurate time pulse is input on the external interrupts. It is also possible to supply hardware frequency aiding by connecting a continuous signal to an external interrupt.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0B</class>
+      <id>0x01</id>
+      <length>48</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>ecefXOrLat</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF X coordinate or latitude,
+depending on flags below</comment>
+          <scale>-</scale>
+          <unit>cm_or_deg*1e-7</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ecefYOrLon</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Y coordinate or longitude,
+depending on flags below</comment>
+          <scale>-</scale>
+          <unit>cm_or_deg*1e-7</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefZOrAlt</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Z coordinate or altitude,
+depending on flags below</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>posAcc</name>
+          <type>U4</type>
+          <comment>Position accuracy (stddev)</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tmCfg</name>
+          <type>X2</type>
+          <comment>Time mark configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>fEdge</name>
+              <description>use falling edge (default rising)</description>
+            </type>
+            <type>
+              <index>2:3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>tm1</name>
+              <description>time mark on extint 1 (default extint 0)</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>f1</name>
+              <description>frequency on extint 1 (default extint 0)</description>
+            </type>
+            <type>
+              <index>7:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>wnoOrDate</name>
+          <type>U2</type>
+          <comment>Actual week number or
+yearSince2000/Month (YYMM),
+depending on flags below</comment>
+          <scale>-</scale>
+          <unit>week_or_yearMonth</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>towOrTime</name>
+          <type>U4</type>
+          <comment>Actual time of week or
+DayOfMonth/Hour/Minute/Second
+(DDHHMMSS), depending on flags below</comment>
+          <scale>-</scale>
+          <unit>ms_or_dayHourMinuteSec</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>towNs</name>
+          <type>I4</type>
+          <comment>Fractional part of time of week</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>tAccMs</name>
+          <type>U4</type>
+          <comment>Milliseconds part of time accuracy</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>tAccNs</name>
+          <type>U4</type>
+          <comment>Nanoseconds part of time accuracy</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>clkDOrFreq</name>
+          <type>I4</type>
+          <comment>Clock drift or frequency, depending on
+flags below</comment>
+          <scale>-</scale>
+          <unit>ns/s_or_Hz*1e-2</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>clkDAccOrFreqAcc</name>
+          <type>U4</type>
+          <comment>Accuracy of clock drift or frequency,
+depending on flags below</comment>
+          <scale>-</scale>
+          <unit>ns/s_or_ppb</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>Bitmask with the following flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>pos</name>
+              <description>Position is valid</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>time</name>
+              <description>Time is valid</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>clockD</name>
+              <description>Clock drift data contains valid clock drift, must not be set together with clockF</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>tp</name>
+              <description>Use time pulse</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>clockF</name>
+              <description>Clock drift data contains valid frequency, must not be set together with clockD</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>lla</name>
+              <description>Position is given in lat/long/alt (default is ECEF)</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>altInv</name>
+              <description>Altitude is not valid, if lla was set</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>prevTm</name>
+              <description>Use time mark received before AID-INI message (default uses mark received after message)</description>
+            </type>
+            <type>
+              <index>8:9</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>utc</name>
+              <description>Time is given as UTC date/time (default is GPS wno/tow)</description>
+            </type>
+            <type>
+              <index>11:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ANT</name>
+    <type>Get/set</type>
+    <description>Antenna control settings</description>
+    <comment>This message allows the user to configure the antenna supervisor. The antenna supervisor can be used to detect the status of an active antenna and control it. It can be used to turn off the supply to the antenna in the event of a short cirquit (for example) or to manage power consumption in power save mode. Refer to antenna supervisor configuration in the Integration manual for more information regarding the behavior of the antenna supervisor. Refer to UBX-MON-HW for a description of the fields in the message used to obtain the status of the antenna. Note that not all pins can be used for antenna supervisor operation, it is recommended that you use the default pins, consult the Integration manual if you need to use other pins.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x13</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Antenna flag mask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>svcs</name>
+              <description>Enable antenna supply voltage control signal</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>scd</name>
+              <description>Enable short circuit detection</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>ocd</name>
+              <description>Enable open circuit detection</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>pdwnOnSCD</name>
+              <description>Power down antenna supply if short circuit is detected. (only in combination with bit 1)</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>recovery</name>
+              <description>Enable automatic recovery from short state</description>
+            </type>
+            <type>
+              <index>5:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>pins</name>
+          <type>X2</type>
+          <comment>Antenna pin configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:4</index>
+              <type>unsigned value</type>
+              <name>pinSwitch</name>
+              <description>PIO-pin used for switching antenna supply</description>
+            </type>
+            <type>
+              <index>5:9</index>
+              <type>unsigned value</type>
+              <name>pinSCD</name>
+              <description>PIO-pin used for detecting a short in the antenna supply</description>
+            </type>
+            <type>
+              <index>10:14</index>
+              <type>unsigned value</type>
+              <name>pinOCD</name>
+              <description>PIO-pin used for detecting open/not connected antenna</description>
+            </type>
+            <type>
+              <index>15</index>
+              <type>unsigned value</type>
+              <name>reconfig</name>
+              <description>if set to one, and this command is sent to the receiver, the receiver will reconfigure the pins as
+specified.</description>
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-BATCH</name>
+    <type>Get/set</type>
+    <description>Get/set data batching configuration</description>
+    <comment>Gets or sets the configuration for data batching. See Data Batching for more information.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x93</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>enable</name>
+              <description>Enable data batching</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>extraPvt</name>
+              <description>Store extra PVT information
+The fields iTOW, tAcc, numSV, hMSL, vAcc, velN, velE, velD, sAcc, headAcc and pDOP in UBX-LOG-
+BATCH are only valid if this flag is set.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>extraOdo</name>
+              <description>Store odometer data
+The fields distance, totalDistance and distanceStd in UBX-LOG-BATCH are only valid if this flag is
+set.
+Note: the odometer feature itself must also be enabled.</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>pioEnable</name>
+              <description>Enable PIO notification</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>pioActiveLow</name>
+              <description>PIO is active low</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>bufSize</name>
+          <type>U2</type>
+          <comment>Size of buffer in number of epochs to store</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>notifThrs</name>
+          <type>U2</type>
+          <comment>Buffer fill level that triggers PIO
+notification, in number of epochs stored</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>pioId</name>
+          <type>U1</type>
+          <comment>PIO ID to use for buffer level notification</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-CFG</name>
+    <type>Command</type>
+    <description>Clear, save and load configurations</description>
+    <comment>See Receiver configuration for a detailed description on how receiver configuration should be used. The three masks are made up of individual bits, each bit indicating the sub-section of all configurations on which the corresponding action shall be carried out. The reserved bits in the masks must be set to '0'. For detailed information refer to the Organization of the configuration sections. Note that commands can be combined. The sequence of execution is clear, save, load.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x09</id>
+      <length>(12) or (13)</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>clearMask</name>
+          <type>X4</type>
+          <comment>Mask with configuration sub-sections to
+clear (i.e. load default configurations to
+permanent configurations in non-volatile
+memory)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>ioPort</name>
+              <description>Communications port settings. Modifying this sub-section results in an IO system reset. Because of
+this undefined data may be output for a short period of time after receiving the message.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>msgConf</name>
+              <description>Message configuration</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>infMsg</name>
+              <description>INF message configuration</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>navConf</name>
+              <description>Navigation configuration</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>rxmConf</name>
+              <description>Receiver Manager configuration</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>senConf</name>
+              <description>Sensor interface configuration (not supported in protocol versions less than 19)</description>
+            </type>
+            <type>
+              <index>9</index>
+              <type>unsigned value</type>
+              <name>rinvConf</name>
+              <description>Remote inventory configuration</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>antConf</name>
+              <description>Antenna configuration</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>logConf</name>
+              <description>Logging configuration</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>ftsConf</name>
+              <description>FTS configuration. Only applicable to the FTS product variant.</description>
+            </type>
+            <type>
+              <index>13:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>saveMask</name>
+          <type>X4</type>
+          <comment>Mask with configuration sub-sections to
+save (i.e. save current configurations to
+non-volatile memory), see ID description of
+clearMask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>loadMask</name>
+          <type>X4</type>
+          <comment>Mask with configuration sub-sections to
+load (i.e. load permanent configurations
+from non-volatile memory to current
+configurations), see ID description of
+clearMask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block type="optional">
+          <block>
+            <offset>12</offset>
+            <name>deviceMask</name>
+            <type>X1</type>
+            <comment>Mask which selects the memory devices
+for this command.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>devBBR</name>
+                <description>Battery backed RAM</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>devFlash</name>
+                <description>Flash</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>devEEPROM</name>
+                <description>EEPROM</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+              <type>
+                <index>4</index>
+                <type>unsigned value</type>
+                <name>devSpiFlash</name>
+                <description>SPI Flash</description>
+              </type>
+              <type>
+                <index>5:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-DAT</name>
+    <type>Set</type>
+    <description>Set user-defined datum</description>
+    <comment>For more information see the description of Geodetic Systems and Frames.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x06</id>
+      <length>44</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>majA</name>
+          <type>R8</type>
+          <comment>Semi-major axis ( accepted range = 6,300,
+000.0 to 6,500,000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>flat</name>
+          <type>R8</type>
+          <comment>1.0 / flattening ( accepted range is 0.0 to
+500.0 ).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>dX</name>
+          <type>R4</type>
+          <comment>X axis shift at the origin ( accepted range
+is +/- 5000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>dY</name>
+          <type>R4</type>
+          <comment>Y axis shift at the origin ( accepted range
+is +/- 5000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>dZ</name>
+          <type>R4</type>
+          <comment>Z axis shift at the origin ( accepted range
+is +/- 5000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>rotX</name>
+          <type>R4</type>
+          <comment>Rotation about the X axis ( accepted range
+is +/- 20.0 milli-arc seconds ).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>rotY</name>
+          <type>R4</type>
+          <comment>Rotation about the Y axis ( accepted range
+is +/- 20.0 milli-arc seconds ).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>rotZ</name>
+          <type>R4</type>
+          <comment>Rotation about the Z axis ( accepted range
+is +/- 20.0 milli-arc seconds ).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>scale</name>
+          <type>R4</type>
+          <comment>Scale change ( accepted range is 0.0 to
+50.0 parts per million ).</comment>
+          <scale>-</scale>
+          <unit>ppm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-DAT</name>
+    <type>Get</type>
+    <description>Get currently defined datum</description>
+    <comment>Returns the parameters of the currently defined datum. If no user-defined datum has been set, this will default to WGS84.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x06</id>
+      <length>52</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>datumNum</name>
+          <type>U2</type>
+          <comment>Datum number: 0 = WGS84, 0xFFFF =
+user-defined</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>datumName</name>
+          <type>CH[6]</type>
+          <comment>ASCII string: WGS84 or USER</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>majA</name>
+          <type>R8</type>
+          <comment>Semi-major axis ( accepted range = 6,300,
+000.0 to 6,500,000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>flat</name>
+          <type>R8</type>
+          <comment>1.0 / flattening ( accepted range is 0.0 to
+500.0 ).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>dX</name>
+          <type>R4</type>
+          <comment>X axis shift at the origin ( accepted range
+is +/- 5000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>dY</name>
+          <type>R4</type>
+          <comment>Y axis shift at the origin ( accepted range
+is +/- 5000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>dZ</name>
+          <type>R4</type>
+          <comment>Z axis shift at the origin ( accepted range
+is +/- 5000.0 meters ).</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>rotX</name>
+          <type>R4</type>
+          <comment>Rotation about the X axis ( accepted range
+is +/- 20.0 milli-arc seconds ).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>rotY</name>
+          <type>R4</type>
+          <comment>Rotation about the Y axis ( accepted range
+is +/- 20.0 milli-arc seconds ).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>rotZ</name>
+          <type>R4</type>
+          <comment>Rotation about the Z axis ( accepted range
+is +/- 20.0 milli-arc seconds ).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>scale</name>
+          <type>R4</type>
+          <comment>Scale change ( accepted range is 0.0 to
+50.0 parts per million ).</comment>
+          <scale>-</scale>
+          <unit>ppm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-DGNSS</name>
+    <type>Get/set</type>
+    <description>DGNSS configuration</description>
+    <comment>This message allows the user to configure the DGNSS configuration of the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with High Precision GNSS products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x70</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>dgnssMode</name>
+          <type>U1</type>
+          <comment>Specifies differential mode:
+2: RTK float: No attempts are made to fix
+ambiguities.
+3: RTK fixed: Ambiguities are fixed
+whenever possible.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-DOSC</name>
+    <type>Get/set</type>
+    <description>Disciplined oscillator configuration</description>
+    <comment>This message allows the characteristics of the internal or external oscillator to be described to the receiver. The gainVco and gainUncertainty parameters are normally set using the calibration process initiated using UBX-TIM-VCOCAL. The behavior of the system can be badly affected by setting the wrong values, so customers are advised to only change these parameters with care.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x61</id>
+      <length>4 + 32*numOsc</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>numOsc</name>
+          <type>U1</type>
+          <comment>Number of oscillators to configure (affects
+length of this message)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numOsc" type="repeated">
+          <block>
+            <offset>4 + 32*N</offset>
+            <name>oscId</name>
+            <type>U1</type>
+            <comment>Id of oscillator.
+0 - internal oscillator
+1 - external oscillator</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>5 + 32*N</offset>
+            <name>reserved2</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>6 + 32*N</offset>
+            <name>flags</name>
+            <type>X2</type>
+            <comment>flags</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>isCalibrated</name>
+                <description>1 if the oscillator gain is calibrated, 0 if not</description>
+              </type>
+              <type>
+                <index>1:4</index>
+                <type>unsigned value</type>
+                <name>controlIf</name>
+                <description>Communication interface for oscillator control:
+0: Custom DAC attached to receiver's I2C
+1: Microchip MCP4726 (12 bit DAC) attached to receiver's I2C
+2: TI DAC8571 (16 bit DAC) attached to receiver's I2C
+13: 12 bit DAC attached to host
+14: 14 bit DAC attached to host
+15: 16 bit DAC attached to host
+Note that for DACs attached to the host, the host must monitor UBX-TIM-DOSC messages and pass
+the supplied raw values on to the DAC.</description>
+              </type>
+              <type>
+                <index>5:15</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>8 + 32*N</offset>
+            <name>freq</name>
+            <type>U4</type>
+            <comment>Nominal frequency of source</comment>
+            <scale>2^-2</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>12 + 32*N</offset>
+            <name>phaseOffset</name>
+            <type>I4</type>
+            <comment>Intended phase offset of the oscillator
+relative to the leading edge of the time
+pulse</comment>
+            <scale>-</scale>
+            <unit>ps</unit>
+          </block>
+          <block>
+            <offset>16 + 32*N</offset>
+            <name>withTemp</name>
+            <type>U4</type>
+            <comment>Oscillator stability limit over operating
+temperature range (must be &gt; 0)</comment>
+            <scale>2^-8</scale>
+            <unit>ppb</unit>
+          </block>
+          <block>
+            <offset>20 + 32*N</offset>
+            <name>withAge</name>
+            <type>U4</type>
+            <comment>Oscillator stability with age (must be &gt; 0)</comment>
+            <scale>2^-8</scale>
+            <unit>ppb/year</unit>
+          </block>
+          <block>
+            <offset>24 + 32*N</offset>
+            <name>timeToTemp</name>
+            <type>U2</type>
+            <comment>The minimum time that it could take for a
+temperature variation to move the
+oscillator frequency by 'withTemp' (must
+be &gt; 0)</comment>
+            <scale>-</scale>
+            <unit>s</unit>
+          </block>
+          <block>
+            <offset>26 + 32*N</offset>
+            <name>reserved3</name>
+            <type>U1[2]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>28 + 32*N</offset>
+            <name>gainVco</name>
+            <type>I4</type>
+            <comment>Oscillator control gain/slope; change of
+frequency per unit change in raw control
+change</comment>
+            <scale>2^-16</scale>
+            <unit>ppb/raw LSB</unit>
+          </block>
+          <block>
+            <offset>32 + 32*N</offset>
+            <name>gainUncertainty</name>
+            <type>U1</type>
+            <comment>Relative uncertainty (1 standard deviation)
+of oscillator control gain/slope</comment>
+            <scale>2^-8</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>33 + 32*N</offset>
+            <name>reserved4</name>
+            <type>U1[3]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ESRC</name>
+    <type>Get/set</type>
+    <description>External synchronization source configuration</description>
+    <comment>External time or frequency source configuration. The stability of time and frequency sources is described using different fields, see sourceType field documentation.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x60</id>
+      <length>4 + 36*numSources</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>numSources</name>
+          <type>U1</type>
+          <comment>Number of sources (affects length of this
+message)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSources" type="repeated">
+          <block>
+            <offset>4 + 36*N</offset>
+            <name>extInt</name>
+            <type>U1</type>
+            <comment>EXTINT index of this source (0 for
+EXTINT0 and 1 for EXTINT1)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>5 + 36*N</offset>
+            <name>sourceType</name>
+            <type>U1</type>
+            <comment>Source type:
+0:  none
+1: frequency source; use withTemp,
+withAge, timeToTemp and
+maxDevLifeTime to describe the stability
+of the source
+2:  time source; use offset,
+offsetUncertainty and jitter fields to
+describe the stability of the source
+3:  feedback from external oscillator;
+stability data is taken from the external
+oscillator's configuration</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>6 + 36*N</offset>
+            <name>flags</name>
+            <type>X2</type>
+            <comment>Flags</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>polarity</name>
+                <description>Polarity of signal:
+0: leading edge is rising edge
+1: leading edge is falling edge</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>gnssUtc</name>
+                <description>Time base of timing signal:
+0: GNSS - as specified in CFG-TP5 (or GPS if CFG-TP5 indicates UTC)
+1: UTC
+Only used if sourceType is 2.</description>
+              </type>
+              <type>
+                <index>2:15</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>8 + 36*N</offset>
+            <name>freq</name>
+            <type>U4</type>
+            <comment>Nominal frequency of source</comment>
+            <scale>2^-2</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>12 + 36*N</offset>
+            <name>reserved2</name>
+            <type>U1[4]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>16 + 36*N</offset>
+            <name>withTemp</name>
+            <type>U4</type>
+            <comment>Oscillator stability limit over operating
+temperature range (must be &gt; 0)
+Only used if sourceType is 1.</comment>
+            <scale>2^-8</scale>
+            <unit>ppb</unit>
+          </block>
+          <block>
+            <offset>20 + 36*N</offset>
+            <name>withAge</name>
+            <type>U4</type>
+            <comment>Oscillator stability with age (must be &gt; 0)
+Only used if sourceType is 1.</comment>
+            <scale>2^-8</scale>
+            <unit>ppb/year</unit>
+          </block>
+          <block>
+            <offset>24 + 36*N</offset>
+            <name>timeToTemp</name>
+            <type>U2</type>
+            <comment>The minimum time that it could take for a
+temperature variation to move the
+oscillator frequency by 'withTemp' (must
+be &gt; 0)
+Only used if sourceType is 1.</comment>
+            <scale>-</scale>
+            <unit>s</unit>
+          </block>
+          <block>
+            <offset>26 + 36*N</offset>
+            <name>maxDevLifeTime</name>
+            <type>U2</type>
+            <comment>Maximum frequency deviation during
+lifetime (must be &gt; 0)
+Only used if sourceType is 1.</comment>
+            <scale>-</scale>
+            <unit>ppb</unit>
+          </block>
+          <block>
+            <offset>28 + 36*N</offset>
+            <name>offset</name>
+            <type>I4</type>
+            <comment>Phase offset of signal
+Only used if sourceType is 2.</comment>
+            <scale>-</scale>
+            <unit>ns</unit>
+          </block>
+          <block>
+            <offset>32 + 36*N</offset>
+            <name>offsetUncertainty</name>
+            <type>U4</type>
+            <comment>Uncertainty of phase offset (one standard
+deviation)
+Only used if sourceType is 2.</comment>
+            <scale>-</scale>
+            <unit>ns</unit>
+          </block>
+          <block>
+            <offset>36 + 36*N</offset>
+            <name>jitter</name>
+            <type>U4</type>
+            <comment>Phase jitter (must be &gt; 0)
+Only used if sourceType is 2.</comment>
+            <scale>-</scale>
+            <unit>ns/s</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-GEOFENCE</name>
+    <type>Get/set</type>
+    <description>Geofencing configuration</description>
+    <comment>Gets or sets the geofencing configuration. See the Geofencing description for feature details. If the receiver is sent a valid new configuration, it will respond with a UBX-ACK- ACK message and immediately change to the new configuration. Otherwise the receiver will reject the request, by issuing a UBX-ACK-NAK and continuing operation with the previous configuration. Note that the acknowledge message does not indicate whether the PIO configuration has been successfully applied (pin assigned), it only indicates the successful configuration of the feature. The configured PIO must be previously unoccupied for successful assignment.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x69</id>
+      <length>8 + 12*numFences</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>numFences</name>
+          <type>U1</type>
+          <comment>Number of geofences contained in this
+message. Note that the receiver can only
+store a limited number of geofences
+(currently 4).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>confLvl</name>
+          <type>U1</type>
+          <comment>Required confidence level for state
+evaluation. This value times the position's
+standard deviation (sigma) defines the
+confidence band.
+0 = no confidence required
+1 = 68%
+2 = 95%
+3 = 99.7%
+4 = 99.99%</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1[1]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>pioEnabled</name>
+          <type>U1</type>
+          <comment>1 = Enable PIO combined fence state
+output, 0 = disable</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>pinPolarity</name>
+          <type>U1</type>
+          <comment>PIO pin polarity. 0 = Low means inside, 1 =
+Low means outside. Unknown state is
+always high.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>pin</name>
+          <type>U1</type>
+          <comment>PIO pin number</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved2</name>
+          <type>U1[1]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numFences" type="repeated">
+          <block>
+            <offset>8 + 12*N</offset>
+            <name>lat</name>
+            <type>I4</type>
+            <comment>Latitude of the geofence circle center</comment>
+            <scale>1e-7</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>12 + 12*N</offset>
+            <name>lon</name>
+            <type>I4</type>
+            <comment>Longitude of the geofence circle center</comment>
+            <scale>1e-7</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>16 + 12*N</offset>
+            <name>radius</name>
+            <type>U4</type>
+            <comment>Radius of the geofence circle</comment>
+            <scale>1e-2</scale>
+            <unit>m</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-GNSS</name>
+    <type>Get/set</type>
+    <description>GNSS system configuration</description>
+    <comment>Gets or sets the GNSS system channel sharing configuration. If the receiver is sent a valid new configuration, it will respond with a UBX-ACK- ACK message and immediately change to the new configuration. Otherwise the receiver will reject the request, by issuing a UBX-ACK-NAK and continuing operation with the previous configuration. Configuration requirements:  It is necessary for at least one major GNSS to be enabled, after applying the  new configuration to the current one.  It is also required that at least 4 tracking channels are available to each enabled  major GNSS, i.e. maxTrkCh must have a minimum value of 4 for each enabled  major GNSS.  The number of tracking channels in use must not exceed the number of  tracking channels available in hardware, and the sum of all reserved tracking  channels needs to be less than or equal to the number of tracking channels in  use. Notes:  To avoid cross-correlation issues, it is recommended that GPS and QZSS are  always both enabled or both disabled.  Polling this message returns the configuration of all supported GNSS, whether  enabled or not; it may also include GNSS unsupported by the particular  product, but in such cases the enable flag will always be unset.  See section GNSS Configuration for a discussion of the use of this message.  See section Satellite Numbering for a description of the GNSS IDs available.  Configuration specific to the GNSS system can be done via other messages (e.  g. UBX-CFG-SBAS).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x3E</id>
+      <length>4 + 8*numConfigBlocks</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>msgVer</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>numTrkChHw</name>
+          <type>U1</type>
+          <comment>Number of tracking channels available in
+hardware (read only)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>numTrkChUse</name>
+          <type>U1</type>
+          <comment>(Read only in protocol versions greater
+than 23) Number of tracking channels to
+use. Must be &gt; 0, &lt;= numTrkChHw. If
+0xFF, then number of tracking channels to
+use will be set to numTrkChHw.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>numConfigBlocks</name>
+          <type>U1</type>
+          <comment>Number of configuration blocks following</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numConfigBlocks" type="repeated">
+          <block>
+            <offset>4 + 8*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>System identifier (see Satellite Numbering
+)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>5 + 8*N</offset>
+            <name>resTrkCh</name>
+            <type>U1</type>
+            <comment>(Read only in protocol versions greater
+than 23) Number of reserved (minimum)
+tracking channels for this system.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>6 + 8*N</offset>
+            <name>maxTrkCh</name>
+            <type>U1</type>
+            <comment>(Read only in protocol versions greater
+than 23) Maximum number of tracking
+channels used for this system. Must be &gt;
+0, &gt;= resTrkChn, &lt;= numTrkChUse and &lt;=
+maximum number of tracking channels
+supported for this system.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>7 + 8*N</offset>
+            <name>reserved1</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>8 + 8*N</offset>
+            <name>flags</name>
+            <type>X4</type>
+            <comment>Bitfield of flags. At least one signal must
+be configured in every enabled system.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>enable</name>
+                <description>Enable this system</description>
+              </type>
+              <type>
+                <index>1:15</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+              <type>
+                <index>16:23</index>
+                <type>unsigned value</type>
+                <name>sigCfgMask</name>
+                <description>Signal configuration mask
+When gnssId is 0 (GPS)
+0x01 = GPS L1C/A
+0x10 = GPS L2C
+When gnssId is 1 (SBAS)
+0x01 = SBAS L1C/A
+When gnssId is 2 (Galileo)
+0x01 = Galileo E1 (not supported in protocol versions less than 18)
+0x20 = Galileo E5b
+When gnssId is 3 (BeiDou)
+0x01 = BeiDou B1I
+0x10 = BeiDou B2I
+When gnssId is 4 (IMES)
+0x01 = IMES L1
+When gnssId is 5 (QZSS)
+0x01 = QZSS L1C/A
+0x04 = QZSS L1S
+0x10 = QZSS L2C
+When gnssId is 6 (GLONASS)
+0x01 = GLONASS L1
+0x10 = GLONASS L2</description>
+              </type>
+              <type>
+                <index>24:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-HNR</name>
+    <type>Get/set</type>
+    <description>High navigation rate settings</description>
+    <comment>The u-blox receivers support high rates of navigation update up to 30 Hz. The navigation solution output UBX-NAV-HNR will not be aligned to the top of a second.  The update rate has a direct influence on the power consumption. The more  fixes that are required, the more CPU power and communication resources are   required.   For most applications a 1 Hz update rate would be sufficient.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16 and 17 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x5C</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>highNavRate</name>
+          <type>U1</type>
+          <comment>Rate of navigation solution output</comment>
+          <scale>-</scale>
+          <unit>Hz</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-INF</name>
+    <type>Poll Request</type>
+    <description>Poll configuration for one protocol</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x02</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>protocolID</name>
+          <type>U1</type>
+          <comment>Protocol identifier, identifying the output
+protocol for this poll request. The
+following are valid protocol identifiers:
+0: UBX protocol
+1: NMEA protocol
+2-255: Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-INF</name>
+    <type>Get/set</type>
+    <description>Information message configuration</description>
+    <comment>The value of infMsgMask[x] below is formed so that each bit represents one of the INF class messages (bit 0 for ERROR, bit 1 for WARNING and so on). For a complete list, see the Message class INF. Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length. Output messages from the module contain only one configuration unit. Note that:   I/O ports 1 and 2 correspond to serial ports 1 and 2.   I/O port 0 is I2C (DDC).   I/O port 3 is USB.   I/O port 4 is SPI.   I/O port 5 is reserved for future use.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x02</id>
+      <length>0 + 10*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*10</offset>
+            <name>protocolID</name>
+            <type>U1</type>
+            <comment>Protocol identifier, identifying for which
+protocol the configuration is set/get. The
+following are valid protocol identifiers:
+0: UBX protocol
+1: NMEA protocol
+2-255: Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>1 + 10*N</offset>
+            <name>reserved1</name>
+            <type>U1[3]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>4 + 10*N</offset>
+            <name>infMsgMask</name>
+            <type>X1[6]</type>
+            <comment>A bit mask, saying which information
+messages are enabled on each I/O port</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>ERROR</name>
+                <description>enable ERROR</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>WARNING</name>
+                <description>enable WARNING</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>NOTICE</name>
+                <description>enable NOTICE</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>unsigned value</type>
+                <name>TEST</name>
+                <description>enable TEST</description>
+              </type>
+              <type>
+                <index>4</index>
+                <type>unsigned value</type>
+                <name>DEBUG</name>
+                <description>enable DEBUG</description>
+              </type>
+              <type>
+                <index>5:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ITFM</name>
+    <type>Get/set</type>
+    <description>Jamming/interference monitor configuration</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x39</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>config</name>
+          <type>X4</type>
+          <comment>Interference config word</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>bbThreshold</name>
+              <description>Broadband jamming detection threshold (unit = dB)</description>
+            </type>
+            <type>
+              <index>4:8</index>
+              <type>unsigned value</type>
+              <name>cwThreshold</name>
+              <description>CW jamming detection threshold (unit = dB)</description>
+            </type>
+            <type>
+              <index>9:30</index>
+              <type>unsigned value</type>
+              <name>algorithmBits</name>
+              <description>Reserved algorithm settings - should be set to 0x16B156 in hex for correct settings</description>
+            </type>
+            <type>
+              <index>31</index>
+              <type>unsigned value</type>
+              <name>enable</name>
+              <description>Enable interference detection</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>config2</name>
+          <type>X4</type>
+          <comment>Extra settings for jamming/interference
+monitor</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:11</index>
+              <type>unsigned value</type>
+              <name>generalBits</name>
+              <description>General settings - should be set to 0x31E in hex for correct setting</description>
+            </type>
+            <type>
+              <index>12:13</index>
+              <type>unsigned value</type>
+              <name>antSetting</name>
+              <description>Antenna setting, 0=unknown, 1=passive, 2=active</description>
+            </type>
+            <type>
+              <index>14</index>
+              <type>unsigned value</type>
+              <name>enable2</name>
+              <description>Set to 1 to scan auxiliary bands (u-blox 8 / u-blox M8 only, otherwise ignored)</description>
+            </type>
+            <type>
+              <index>15:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-LOGFILTER</name>
+    <type>Get/set</type>
+    <description>Data logger configuration</description>
+    <comment>This message can be used to configure the data logger, i.e. to enable/disable the log recording and to get/set the position entry filter settings. Position entries can be filtered based on time difference, position difference or current speed thresholds. Position and speed filtering also have a minimum time interval. A position is logged if any of the thresholds are exceeded. If a threshold is set to zero it is ignored. The maximum rate of position logging is 1 Hz. The filter settings will be configured to the provided values only if the 'applyAllFilterSettings' flag is set. This allows the recording to be enabled/disabled independently of configuring the filter settings. Configuring the data logger in the absence of a logging file is supported. By doing so, once the logging file is created, the data logger configuration will take effect immediately and logging recording and filtering will activate according to the configuration.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x47</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>recordEnabled</name>
+              <description>1 = enable recording, 0 = disable recording</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>psmOncePerWakupEnabled</name>
+              <description>1 = enable recording only one single position per PSM on/off mode wake-up period, 0 = disable once per wake-up</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>applyAllFilterSettings</name>
+              <description>1 = apply all filter settings, 0 = only apply recordEnabled</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>minInterval</name>
+          <type>U2</type>
+          <comment>Minimum time interval between logged
+positions (0 = not set). This is only applied
+in combination with the speed and/or
+position thresholds. If both minInterval
+and timeThreshold are set, minInterval
+must be less than or equal to
+timeThreshold.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>timeThreshold</name>
+          <type>U2</type>
+          <comment>If the time difference is greater than the
+threshold, then the position is logged (0 =
+not set).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>speedThreshold</name>
+          <type>U2</type>
+          <comment>If the current speed is greater than the
+threshold, then the position is logged (0 =
+not set). minInterval also applies.</comment>
+          <scale>-</scale>
+          <unit>m/s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>positionThreshold</name>
+          <type>U4</type>
+          <comment>If the 3D position difference is greater
+than the threshold, then the position is
+logged (0 = not set). minInterval also
+applies.</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-MSG</name>
+    <type>Poll Request</type>
+    <description>Poll a message configuration</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x01</id>
+      <length>2</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>msgClass</name>
+          <type>U1</type>
+          <comment>Message class</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>msgID</name>
+          <type>U1</type>
+          <comment>Message identifier</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-MSG</name>
+    <type>Get/set</type>
+    <description>Set message rate(s)</description>
+    <comment>Get/set message rate configuration (s) to/from the receiver. See also section How to change between protocols.  Send rate is relative to the event a message is registered on. For example, if the  rate of a navigation message is set to 2, the message is sent every second  navigation solution. For configuring NMEA messages, the section NMEA  Messages Overview describes class and identifier numbers used.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x01</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>msgClass</name>
+          <type>U1</type>
+          <comment>Message class</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>msgID</name>
+          <type>U1</type>
+          <comment>Message identifier</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>rate</name>
+          <type>U1[6]</type>
+          <comment>Send rate on I/O port (6 ports)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-MSG</name>
+    <type>Get/set</type>
+    <description>Set message rate</description>
+    <comment>Set message rate configuration for the current port. See also section How to change between protocols.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x01</id>
+      <length>3</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>msgClass</name>
+          <type>U1</type>
+          <comment>Message class</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>msgID</name>
+          <type>U1</type>
+          <comment>Message identifier</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>rate</name>
+          <type>U1</type>
+          <comment>Send rate on current port</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NAV5</name>
+    <type>Get/set</type>
+    <description>Navigation engine settings</description>
+    <comment>See the Navigation Configuration Settings Description for a detailed description of how these settings affect receiver operation.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x24</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>mask</name>
+          <type>X2</type>
+          <comment>Parameters bitmask. Only the masked
+parameters will be applied.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>dyn</name>
+              <description>Apply dynamic model settings</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>minEl</name>
+              <description>Apply minimum elevation settings</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>posFixMode</name>
+              <description>Apply fix mode settings</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>drLim</name>
+              <description>Reserved</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>posMask</name>
+              <description>Apply position mask settings</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>timeMask</name>
+              <description>Apply time mask settings</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>staticHoldMask</name>
+              <description>Apply static hold settings</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>dgpsMask</name>
+              <description>Apply DGPS settings</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>cnoThreshold</name>
+              <description>Apply CNO threshold settings (cnoThresh, cnoThreshNumSVs)</description>
+            </type>
+            <type>
+              <index>9</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>utc</name>
+              <description>Apply UTC settings
+(not supported in protocol versions less than 16).</description>
+            </type>
+            <type>
+              <index>11:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>dynModel</name>
+          <type>U1</type>
+          <comment>Dynamic platform model:
+0: portable
+2: stationary
+3: pedestrian
+4: automotive
+5: sea
+6: airborne with &lt;1g acceleration
+7: airborne with &lt;2g acceleration
+8: airborne with &lt;4g acceleration
+9: wrist-worn watch (not supported in
+protocol versions less than 18)
+10: bike (supported in protocol versions 19.
+2)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>fixMode</name>
+          <type>U1</type>
+          <comment>Position fixing mode:
+1: 2D only
+2: 3D only
+3: auto 2D/3D</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>fixedAlt</name>
+          <type>I4</type>
+          <comment>Fixed altitude (mean sea level) for 2D fix
+mode</comment>
+          <scale>0.01</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>fixedAltVar</name>
+          <type>U4</type>
+          <comment>Fixed altitude variance for 2D mode</comment>
+          <scale>0.0001</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>minElev</name>
+          <type>I1</type>
+          <comment>Minimum elevation for a GNSS satellite to
+be used in NAV</comment>
+          <scale>-</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>drLimit</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>pDop</name>
+          <type>U2</type>
+          <comment>Position DOP mask to use</comment>
+          <scale>0.1</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tDop</name>
+          <type>U2</type>
+          <comment>Time DOP mask to use</comment>
+          <scale>0.1</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>pAcc</name>
+          <type>U2</type>
+          <comment>Position accuracy mask</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>tAcc</name>
+          <type>U2</type>
+          <comment>Time accuracy mask</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>staticHoldThresh</name>
+          <type>U1</type>
+          <comment>Static hold threshold</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>dgnssTimeout</name>
+          <type>U1</type>
+          <comment>DGNSS timeout</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>cnoThreshNumSVs</name>
+          <type>U1</type>
+          <comment>Number of satellites required to have
+C/N0 above cnoThresh for a fix to be
+attempted</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>cnoThresh</name>
+          <type>U1</type>
+          <comment>C/N0 threshold for deciding whether to
+attempt a fix</comment>
+          <scale>-</scale>
+          <unit>dBHz</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>staticHoldMaxDist</name>
+          <type>U2</type>
+          <comment>Static hold distance threshold (before
+quitting static hold)</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>utcStandard</name>
+          <type>U1</type>
+          <comment>UTC standard to be used:
+0: Automatic; receiver selects based on
+GNSS configuration (see GNSS time
+bases)
+3: UTC as operated by the U.S. Naval
+Observatory (USNO); derived from GPS
+time
+5: UTC as combined from multiple
+European laboratories; derived from
+Galileo time
+6: UTC as operated by the former Soviet
+Union (SU); derived from GLONASS time
+7: UTC as operated by the National Time
+Service Center (NTSC), China; derived
+from BeiDou time
+(not supported in protocol versions less
+than 16).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>31</offset>
+          <name>reserved2</name>
+          <type>U1[5]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NAVX5</name>
+    <type>Get/set</type>
+    <description>Navigation engine expert settings</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16 and 17</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x23</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U2</type>
+          <comment>Message version (0x0000 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>mask1</name>
+          <type>X2</type>
+          <comment>First parameters bitmask. Only the
+flagged parameters will be applied,
+unused bits must be set to 0.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:1</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>minMax</name>
+              <description>1 = apply min/max SVs settings</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>minCno</name>
+              <description>1 = apply minimum C/N0 setting</description>
+            </type>
+            <type>
+              <index>4:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>initial3dfix</name>
+              <description>1 = apply initial 3D fix settings</description>
+            </type>
+            <type>
+              <index>7:8</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>9</index>
+              <type>unsigned value</type>
+              <name>wknRoll</name>
+              <description>1 = apply GPS weeknumber rollover settings</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>ackAid</name>
+              <description>1 = apply assistance acknowledgement settings</description>
+            </type>
+            <type>
+              <index>11:12</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>ppp</name>
+              <description>1 = apply usePPP flag</description>
+            </type>
+            <type>
+              <index>14</index>
+              <type>unsigned value</type>
+              <name>aop</name>
+              <description>1 = apply aopCfg (useAOP flag) and aopOrbMaxErr settings (AssistNow Autonomous)</description>
+            </type>
+            <type>
+              <index>15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>mask2</name>
+          <type>X4</type>
+          <comment>Second parameters bitmask. Only the
+flagged parameters will be applied,
+unused bits must be set to 0.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>adr</name>
+              <description>Apply ADR sensor fusion on/off setting (useAdr flag)</description>
+            </type>
+            <type>
+              <index>7:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>minSVs</name>
+          <type>U1</type>
+          <comment>Minimum number of satellites for
+navigation</comment>
+          <scale>-</scale>
+          <unit>#SVs</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>maxSVs</name>
+          <type>U1</type>
+          <comment>Maximum number of satellites for
+navigation</comment>
+          <scale>-</scale>
+          <unit>#SVs</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>minCNO</name>
+          <type>U1</type>
+          <comment>Minimum satellite signal level for
+navigation</comment>
+          <scale>-</scale>
+          <unit>dBHz</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>iniFix3D</name>
+          <type>U1</type>
+          <comment>1 = initial fix must be 3D</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>ackAiding</name>
+          <type>U1</type>
+          <comment>1 = issue acknowledgements for
+assistance message input</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>wknRollover</name>
+          <type>U2</type>
+          <comment>GPS week rollover number; GPS week
+numbers will be set correctly from this
+week up to 1024 weeks after this week.
+Setting this to 0 reverts to firmware
+default.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>reserved4</name>
+          <type>U1[6]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>usePPP</name>
+          <type>U1</type>
+          <comment>1 = use Precise Point Positioning (only
+available with the PPP product variant)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>aopCfg</name>
+          <type>U1</type>
+          <comment>AssistNow Autonomous configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>useAOP</name>
+              <description>1 = enable AssistNow Autonomous</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>reserved5</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>aopOrbMaxErr</name>
+          <type>U2</type>
+          <comment>Maximum acceptable (modeled)
+AssistNow Autonomous orbit error (valid
+range = 5..1000, or 0 = reset to firmware
+default)</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved6</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>reserved7</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>39</offset>
+          <name>useAdr</name>
+          <type>U1</type>
+          <comment>Only supported on certain products
+Enable/disable ADR sensor fusion (if 0:
+sensor fusion is disabled - if 1: sensor
+fusion is enabled).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NAVX5</name>
+    <type>Get/set</type>
+    <description>Navigation engine expert settings</description>
+    <comment>(Polling will send back a version 3 message in protocol versions 19.2).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x23</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U2</type>
+          <comment>Message version (0x0002 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>mask1</name>
+          <type>X2</type>
+          <comment>First parameters bitmask. Only the
+flagged parameters will be applied,
+unused bits must be set to 0.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:1</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>minMax</name>
+              <description>1 = apply min/max SVs settings</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>minCno</name>
+              <description>1 = apply minimum C/N0 setting</description>
+            </type>
+            <type>
+              <index>4:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>initial3dfix</name>
+              <description>1 = apply initial 3D fix settings</description>
+            </type>
+            <type>
+              <index>7:8</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>9</index>
+              <type>unsigned value</type>
+              <name>wknRoll</name>
+              <description>1 = apply GPS weeknumber rollover settings</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>ackAid</name>
+              <description>1 = apply assistance acknowledgement settings</description>
+            </type>
+            <type>
+              <index>11:12</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>ppp</name>
+              <description>1 = apply usePPP flag</description>
+            </type>
+            <type>
+              <index>14</index>
+              <type>unsigned value</type>
+              <name>aop</name>
+              <description>1 = apply aopCfg (useAOP flag) and aopOrbMaxErr settings (AssistNow Autonomous)</description>
+            </type>
+            <type>
+              <index>15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>mask2</name>
+          <type>X4</type>
+          <comment>Second parameters bitmask. Only the
+flagged parameters will be applied,
+unused bits must be set to 0.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>adr</name>
+              <description>Apply ADR/UDR sensor fusion on/off setting (useAdr flag)</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>sigAttenComp</name>
+              <description>Only supported on certain products
+Apply signal attenuation compensation feature settings</description>
+            </type>
+            <type>
+              <index>8:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>minSVs</name>
+          <type>U1</type>
+          <comment>Minimum number of satellites for
+navigation</comment>
+          <scale>-</scale>
+          <unit>#SVs</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>maxSVs</name>
+          <type>U1</type>
+          <comment>Maximum number of satellites for
+navigation</comment>
+          <scale>-</scale>
+          <unit>#SVs</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>minCNO</name>
+          <type>U1</type>
+          <comment>Minimum satellite signal level for
+navigation</comment>
+          <scale>-</scale>
+          <unit>dBHz</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>iniFix3D</name>
+          <type>U1</type>
+          <comment>1 = initial fix must be 3D</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>ackAiding</name>
+          <type>U1</type>
+          <comment>1 = issue acknowledgements for
+assistance message input</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>wknRollover</name>
+          <type>U2</type>
+          <comment>GPS week rollover number; GPS week
+numbers will be set correctly from this
+week up to 1024 weeks after this week.
+Setting this to 0 reverts to firmware
+default.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>sigAttenCompMode</name>
+          <type>U1</type>
+          <comment>Only supported on certain products
+Permanently attenuated signal
+compensation (0 = disabled, 255 =
+automatic, 1..63 = maximum expected
+C/N0 value)</comment>
+          <scale>-</scale>
+          <unit>dBHz</unit>
+        </block>
+        <block>
+          <offset>21</offset>
+          <name>reserved4</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>reserved5</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>reserved6</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>usePPP</name>
+          <type>U1</type>
+          <comment>1 = use Precise Point Positioning (only
+available with the PPP product variant)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>aopCfg</name>
+          <type>U1</type>
+          <comment>AssistNow Autonomous configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>useAOP</name>
+              <description>1 = enable AssistNow Autonomous</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>reserved7</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>aopOrbMaxErr</name>
+          <type>U2</type>
+          <comment>Maximum acceptable (modeled)
+AssistNow Autonomous orbit error (valid
+range = 5..1000, or 0 = reset to firmware
+default)</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved8</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>reserved9</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>39</offset>
+          <name>useAdr</name>
+          <type>U1</type>
+          <comment>Only supported on certain products
+Enable/disable ADR/UDR sensor fusion (if
+0: sensor fusion is disabled - if 1: sensor
+fusion is enabled).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NAVX5</name>
+    <type>Get/set</type>
+    <description>Navigation engine expert settings</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19.1 and 19.2</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x23</id>
+      <length>44</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U2</type>
+          <comment>Message version (0x0003 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>mask1</name>
+          <type>X2</type>
+          <comment>First parameters bitmask. Only the
+flagged parameters will be applied,
+unused bits must be set to 0.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:1</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>minMax</name>
+              <description>1 = apply min/max SVs settings</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>minCno</name>
+              <description>1 = apply minimum C/N0 setting</description>
+            </type>
+            <type>
+              <index>4:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>initial3dfix</name>
+              <description>1 = apply initial 3D fix settings</description>
+            </type>
+            <type>
+              <index>7:8</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>9</index>
+              <type>unsigned value</type>
+              <name>wknRoll</name>
+              <description>1 = apply GPS weeknumber rollover settings</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>ackAid</name>
+              <description>1 = apply assistance acknowledgement settings</description>
+            </type>
+            <type>
+              <index>11:12</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>ppp</name>
+              <description>1 = apply usePPP flag</description>
+            </type>
+            <type>
+              <index>14</index>
+              <type>unsigned value</type>
+              <name>aop</name>
+              <description>1 = apply aopCfg (useAOP flag) and aopOrbMaxErr settings (AssistNow Autonomous)</description>
+            </type>
+            <type>
+              <index>15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>mask2</name>
+          <type>X4</type>
+          <comment>Second parameters bitmask. Only the
+flagged parameters will be applied,
+unused bits must be set to 0.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>adr</name>
+              <description>Apply ADR/UDR sensor fusion on/off setting (useAdr flag)</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>sigAttenComp</name>
+              <description>Only supported on certain products
+Apply signal attenuation compensation feature settings</description>
+            </type>
+            <type>
+              <index>8:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>minSVs</name>
+          <type>U1</type>
+          <comment>Minimum number of satellites for
+navigation</comment>
+          <scale>-</scale>
+          <unit>#SVs</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>maxSVs</name>
+          <type>U1</type>
+          <comment>Maximum number of satellites for
+navigation</comment>
+          <scale>-</scale>
+          <unit>#SVs</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>minCNO</name>
+          <type>U1</type>
+          <comment>Minimum satellite signal level for
+navigation</comment>
+          <scale>-</scale>
+          <unit>dBHz</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>iniFix3D</name>
+          <type>U1</type>
+          <comment>1 = initial fix must be 3D</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>ackAiding</name>
+          <type>U1</type>
+          <comment>1 = issue acknowledgements for
+assistance message input</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>wknRollover</name>
+          <type>U2</type>
+          <comment>GPS week rollover number; GPS week
+numbers will be set correctly from this
+week up to 1024 weeks after this week.
+Setting this to 0 reverts to firmware
+default.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>sigAttenCompMode</name>
+          <type>U1</type>
+          <comment>Only supported on certain products
+Permanently attenuated signal
+compensation (0 = disabled, 255 =
+automatic, 1..63 = maximum expected
+C/N0 value)</comment>
+          <scale>-</scale>
+          <unit>dBHz</unit>
+        </block>
+        <block>
+          <offset>21</offset>
+          <name>reserved4</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>reserved5</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>reserved6</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>usePPP</name>
+          <type>U1</type>
+          <comment>1 = use Precise Point Positioning (only
+available with the PPP product variant)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>aopCfg</name>
+          <type>U1</type>
+          <comment>AssistNow Autonomous configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>useAOP</name>
+              <description>1 = enable AssistNow Autonomous</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>reserved7</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>aopOrbMaxErr</name>
+          <type>U2</type>
+          <comment>Maximum acceptable (modeled)
+AssistNow Autonomous orbit error (valid
+range = 5..1000, or 0 = reset to firmware
+default)</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved8</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>reserved9</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>39</offset>
+          <name>useAdr</name>
+          <type>U1</type>
+          <comment>Only supported on certain products
+Enable/disable ADR/UDR sensor fusion (if
+0: sensor fusion is disabled - if 1: sensor
+fusion is enabled).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>reserved10</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>42</offset>
+          <name>reserved11</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NMEA</name>
+    <type>Get/set</type>
+    <description>NMEA protocol configuration (deprecated)</description>
+    <comment>This message version is provided for backwards compatibility only. Use the last version listed below instead (its fields are backwards compatible with this version, it just has extra fields defined). Get/set the NMEA protocol configuration. See section NMEA Protocol Configuration for a detailed description of the configuration effects on NMEA output.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x17</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>filter</name>
+          <type>X1</type>
+          <comment>filter flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>posFilt</name>
+              <description>Enable position output for failed or invalid fixes</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>mskPosFilt</name>
+              <description>Enable position output for invalid fixes</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>timeFilt</name>
+              <description>Enable time output for invalid times</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>dateFilt</name>
+              <description>Enable date output for invalid dates</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>gpsOnlyFilter</name>
+              <description>Restrict output to GPS satellites only</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>trackFilt</name>
+              <description>Enable COG output even if COG is frozen</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>nmeaVersion</name>
+          <type>U1</type>
+          <comment>0x23: NMEA version 2.3
+0x21: NMEA version 2.1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Maximum number of SVs to report per
+TalkerId.
+0: unlimited
+8: 8 SVs
+12: 12 SVs
+16: 16 SVs</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>compat</name>
+              <description>enable compatibility mode.
+This might be needed for certain applications when customer's NMEA parser expects a fixed number
+of digits in position coordinates.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>consider</name>
+              <description>enable considering mode.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NMEA</name>
+    <type>Get/set</type>
+    <description>NMEA protocol configuration V0 (deprecated)</description>
+    <comment>This message version is provided for backwards compatibility only. Use the last version listed below instead (its fields are backwards compatible with this version, it just has extra fields defined). Get/set the NMEA protocol configuration. See section NMEA Protocol Configuration for a detailed description of the configuration effects on NMEA output.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x17</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>filter</name>
+          <type>X1</type>
+          <comment>filter flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>posFilt</name>
+              <description>Enable position output for failed or invalid fixes</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>mskPosFilt</name>
+              <description>Enable position output for invalid fixes</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>timeFilt</name>
+              <description>Enable time output for invalid times</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>dateFilt</name>
+              <description>Enable date output for invalid dates</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>gpsOnlyFilter</name>
+              <description>Restrict output to GPS satellites only</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>trackFilt</name>
+              <description>Enable COG output even if COG is frozen</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>nmeaVersion</name>
+          <type>U1</type>
+          <comment>0x23: NMEA version 2.3
+0x21: NMEA version 2.1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Maximum number of SVs to report per
+TalkerId.
+0: unlimited
+8: 8 SVs
+12: 12 SVs
+16: 16 SVs</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>compat</name>
+              <description>enable compatibility mode.
+This might be needed for certain applications when customer's NMEA parser expects a fixed number
+of digits in position coordinates.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>consider</name>
+              <description>enable considering mode.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>gnssToFilter</name>
+          <type>X4</type>
+          <comment>Filters out satellites based on their GNSS.
+If a bitfield is enabled, the corresponding
+satellites will be not output.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gps</name>
+              <description>Disable reporting of GPS satellites</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>sbas</name>
+              <description>Disable reporting of SBAS satellites</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>galileo</name>
+              <description>Disable reporting of Galileo satellites</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>qzss</name>
+              <description>Disable reporting of QZSS satellites</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>glonass</name>
+              <description>Disable reporting of GLONASS satellites</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>beidou</name>
+              <description>Disable reporting of BeiDou satellites</description>
+            </type>
+            <type>
+              <index>7:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>svNumbering</name>
+          <type>U1</type>
+          <comment>Configures the display of satellites that do
+not have an NMEA-defined value.
+Note: this does not apply to satellites with
+an unknown ID.
+0: Strict - Satellites are not output
+1: Extended - Use proprietary numbering
+(see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>mainTalkerId</name>
+          <type>U1</type>
+          <comment>By default the main Talker ID (i.e. the
+Talker ID used for all messages other than
+GSV) is determined by the GNSS
+assignment of the receiver's channels (see
+UBX-CFG-GNSS).
+This field enables the main Talker ID to be
+overridden.
+0: Main Talker ID is not overridden
+1: Set main Talker ID to 'GP'
+2: Set main Talker ID to 'GL'
+3: Set main Talker ID to 'GN'
+4: Set main Talker ID to 'GA'
+5: Set main Talker ID to 'GB'
+6: Set main Talker ID to 'GQ' (available in
+NMEA 4.11 or later)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>gsvTalkerId</name>
+          <type>U1</type>
+          <comment>By default the Talker ID for GSV messages
+is GNSS-specific (as defined by NMEA).
+This field enables the GSV Talker ID to be
+overridden.
+0: Use GNSS-specific Talker ID (as defined
+by NMEA)
+1: Use the main Talker ID</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-NMEA</name>
+    <type>Get/set</type>
+    <description>Extended NMEA protocol configuration V1</description>
+    <comment>Get/set the NMEA protocol configuration. See section NMEA Protocol Configuration for a detailed description of the configuration effects on NMEA output.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x17</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>filter</name>
+          <type>X1</type>
+          <comment>filter flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>posFilt</name>
+              <description>Enable position output for failed or invalid fixes</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>mskPosFilt</name>
+              <description>Enable position output for invalid fixes</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>timeFilt</name>
+              <description>Enable time output for invalid times</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>dateFilt</name>
+              <description>Enable date output for invalid dates</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>gpsOnlyFilter</name>
+              <description>Restrict output to GPS satellites only</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>trackFilt</name>
+              <description>Enable COG output even if COG is frozen</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>nmeaVersion</name>
+          <type>U1</type>
+          <comment>0x4b: NMEA version 4.11 (not available in
+all products)
+0x41: NMEA version 4.10 (not available in
+all products)
+0x40: NMEA version 4.0 (not available in
+all products)
+0x23: NMEA version 2.3
+0x21: NMEA version 2.1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Maximum number of SVs to report per
+TalkerId.
+0: unlimited
+8: 8 SVs
+12: 12 SVs
+16: 16 SVs</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>compat</name>
+              <description>enable compatibility mode.
+This might be needed for certain applications when customer's NMEA parser expects a fixed number
+of digits in position coordinates.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>consider</name>
+              <description>enable considering mode.</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>limit82</name>
+              <description>enable strict limit to 82 characters maximum.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>highPrec</name>
+              <description>enable high precision mode.
+This flag cannot be set in conjunction with either compatibility mode or Limit82 mode (not
+supported in protocol versions less than 20.01).</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>gnssToFilter</name>
+          <type>X4</type>
+          <comment>Filters out satellites based on their GNSS.
+If a bitfield is enabled, the corresponding
+satellites will be not output.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gps</name>
+              <description>Disable reporting of GPS satellites</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>sbas</name>
+              <description>Disable reporting of SBAS satellites</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>galileo</name>
+              <description>Disable reporting of Galileo satellites</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>qzss</name>
+              <description>Disable reporting of QZSS satellites</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>glonass</name>
+              <description>Disable reporting of GLONASS satellites</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>beidou</name>
+              <description>Disable reporting of BeiDou satellites</description>
+            </type>
+            <type>
+              <index>7:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>svNumbering</name>
+          <type>U1</type>
+          <comment>Configures the display of satellites that do
+not have an NMEA-defined value.
+Note: this does not apply to satellites with
+an unknown ID.
+0: Strict - Satellites are not output
+1: Extended - Use proprietary numbering
+(see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>mainTalkerId</name>
+          <type>U1</type>
+          <comment>By default the main Talker ID (i.e. the
+Talker ID used for all messages other than
+GSV) is determined by the GNSS
+assignment of the receiver's channels (see
+UBX-CFG-GNSS).
+This field enables the main Talker ID to be
+overridden.
+0: Main Talker ID is not overridden
+1: Set main Talker ID to 'GP'
+2: Set main Talker ID to 'GL'
+3: Set main Talker ID to 'GN'
+4: Set main Talker ID to 'GA'
+5: Set main Talker ID to 'GB'
+6: Set main Talker ID to 'GQ' (available in
+NMEA 4.11 or later)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>gsvTalkerId</name>
+          <type>U1</type>
+          <comment>By default the Talker ID for GSV messages
+is GNSS-specific (as defined by NMEA).
+This field enables the GSV Talker ID to be
+overridden.
+0: Use GNSS-specific Talker ID (as defined
+by NMEA)
+1: Use the main Talker ID</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>bdsTalkerId</name>
+          <type>CH[2]</type>
+          <comment>Sets the two characters that should be
+used for the BeiDou Talker ID. If these are
+set to zero, then the default BeiDou Talker
+ID will be used.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>reserved1</name>
+          <type>U1[6]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ODO</name>
+    <type>Get/set</type>
+    <description>Odometer, low-speed COG engine settings</description>
+    <comment>This feature is not supported for the FTS product variant. -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x1E</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>U1</type>
+          <comment>Odometer/Low-speed COG filter flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>useODO</name>
+              <description>Odometer-enabled flag</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>useCOG</name>
+              <description>Low-speed COG filter enabled flag</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>outLPVel</name>
+              <description>Output low-pass filtered velocity flag</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>outLPCog</name>
+              <description>Output low-pass filtered heading (COG) flag</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>odoCfg</name>
+          <type>X1</type>
+          <comment>Odometer filter settings</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:2</index>
+              <type>unsigned value</type>
+              <name>profile</name>
+              <description>Profile type (0=running, 1=cycling, 2=swimming, 3=car, 4=custom)</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved2</name>
+          <type>U1[6]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>cogMaxSpeed</name>
+          <type>U1</type>
+          <comment>Speed below which course-over-ground
+(COG) is computed with the low-speed
+COG filter</comment>
+          <scale>1e-1</scale>
+          <unit>m/s</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>cogMaxPosAcc</name>
+          <type>U1</type>
+          <comment>Maximum acceptable position accuracy
+for computing COG with the low-speed
+COG filter</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>velLpGain</name>
+          <type>U1</type>
+          <comment>Velocity low-pass filter level, range 0..255</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>cogLpGain</name>
+          <type>U1</type>
+          <comment>COG low-pass filter level (at speed &lt; 8
+m/s), range 0..255</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved4</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PM2</name>
+    <type>Get/set</type>
+    <description>Extended power management configuration</description>
+    <comment>This feature is not supported for either the ADR or FTS products. -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x3B</id>
+      <length>44</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>maxStartupStateDur</name>
+          <type>U1</type>
+          <comment>Maximum time to spend in Acquisition
+state. If 0: bound disabled (see
+maxStartupStateDur) (not supported in
+protocol versions less than 17).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>PSM configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>extintSel</name>
+              <description>EXTINT pin select
+0 EXTINT0
+1 EXTINT1</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>extintWake</name>
+              <description>EXTINT pin control
+0 disabled
+1 enabled, keep receiver awake as long as selected EXTINT pin is 'high'</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>extintBackup</name>
+              <description>EXTINT pin control
+0 disabled
+1 enabled, force receiver into BACKUP mode when selected EXTINT pin is 'low'</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>8:9</index>
+              <type>unsigned value</type>
+              <name>limitPeakCurr</name>
+              <description>Limit peak current
+00 disabled
+01 enabled, peak current is limited
+10 reserved
+11 reserved</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>waitTimeFix</name>
+              <description>Wait for Timefix (see waitTimeFix)
+0 wait for normal fix OK before starting on time
+1 wait for time fix OK before starting on time</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>updateRTC</name>
+              <description>Update Real Time Clock (see updateRTC)
+0 do not wake up to update RTC. RTC is updated during normal on-time.
+1 update RTC. The receiver adds extra wake-up cycles to update the RTC.</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>updateEPH</name>
+              <description>Update Ephemeris (see updateEPH)
+0 do not wake up to update Ephemeris data
+1 update Ephemeris. The receiver adds extra wake-up cycles to update the Ephemeris data</description>
+            </type>
+            <type>
+              <index>13:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>16</index>
+              <type>unsigned value</type>
+              <name>doNotEnterOff</name>
+              <description>Behavior of receiver in case of no fix (see doNotEnterOff)
+0 receiver enters Inactive) Awaiting next search state
+1 receiver does not enter (Inactive) Awaiting next search state but keeps trying to acquire a fix
+instead</description>
+            </type>
+            <type>
+              <index>17:18</index>
+              <type>unsigned value</type>
+              <name>mode</name>
+              <description>Mode of operation (see mode)
+00 ON/OFF operation (PSMOO)
+01 cyclic tracking operation (PSMCT)
+10 reserved
+11 reserved</description>
+            </type>
+            <type>
+              <index>19:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>updatePeriod</name>
+          <type>U4</type>
+          <comment>Position update period. If set to 0, the
+receiver will never retry a fix and it will wait
+for external events</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>searchPeriod</name>
+          <type>U4</type>
+          <comment>Acquisition retry period if previously failed.
+If set to 0, the receiver will never retry a
+startup</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>gridOffset</name>
+          <type>U4</type>
+          <comment>Grid offset relative to GPS start of week</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>onTime</name>
+          <type>U2</type>
+          <comment>Time to stay in Tracking state</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>minAcqTime</name>
+          <type>U2</type>
+          <comment>minimal search time</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>reserved3</name>
+          <type>U1[20]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PM2</name>
+    <type>Get/set</type>
+    <description>Extended power management configuration</description>
+    <comment>This feature is not supported for either the ADR or FTS products. -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3 and 22</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x3B</id>
+      <length>48</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x02 for this version)
+Note: the message version number is the
+same as for protocol version 23.01; please
+select correct message version based on
+the protocol version supported by your
+firmware.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>maxStartupStateDur</name>
+          <type>U1</type>
+          <comment>Maximum time to spend in Acquisition
+state. If 0: bound disabled (see
+maxStartupStateDur) (not supported in
+protocol versions less than 17).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>PSM configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>extintSel</name>
+              <description>EXTINT pin select
+0 EXTINT0
+1 EXTINT1</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>extintWake</name>
+              <description>EXTINT Pin Control
+0 disabled
+1 enabled, keep receiver awake as long as selected EXTINT pin is 'high'</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>extintBackup</name>
+              <description>EXTINT Pin Control
+0 disabled
+1 enabled, force receiver into BACKUP mode when selected EXTINT pin is 'low'</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>extintInactive</name>
+              <description>EXTINT Pin Control 0 disabled
+1 enabled, force backup in case EXTINT pin is inactive for time longer than extintIncactivityMs</description>
+            </type>
+            <type>
+              <index>8:9</index>
+              <type>unsigned value</type>
+              <name>limitPeakCurr</name>
+              <description>Limit Peak Current
+00 disabled
+01 enabled, peak current is limited
+10 reserved
+11 reserved</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>waitTimeFix</name>
+              <description>Wait for Timefix (see waitTimeFix)
+0 wait for normal fix OK before starting on time
+1 wait for time fix OK before starting on time</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>updateRTC</name>
+              <description>Update Real Time Clock (see updateRTC)
+0 do not wake up to update RTC. RTC is updated during normal on-time.
+1 update RTC. The receiver adds extra wake-up cycles to update the RTC.</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>updateEPH</name>
+              <description>Update Ephemeris (see updateEPH)
+0 do not wake up to update Ephemeris data
+1 update Ephemeris. The receiver adds extra wake-up cycles to update the Ephemeris data</description>
+            </type>
+            <type>
+              <index>13:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>16</index>
+              <type>unsigned value</type>
+              <name>doNotEnterOff</name>
+              <description>Behavior of receiver in case of no fix (see doNotEnterOff)
+0 receiver enters (Inactive) Awaiting next search state
+1 receiver does not enter (Inactive) Awaiting next search state but keeps trying to acquire a fix
+instead</description>
+            </type>
+            <type>
+              <index>17:18</index>
+              <type>unsigned value</type>
+              <name>mode</name>
+              <description>Mode of operation (see mode)
+00 ON/OFF operation (PSMOO)
+01 cyclic tracking operation (PSMCT)
+10 reserved
+11 reserved</description>
+            </type>
+            <type>
+              <index>19:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>updatePeriod</name>
+          <type>U4</type>
+          <comment>Position update period. If set to 0, the
+receiver will never retry a fix and it will wait
+for external events</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>searchPeriod</name>
+          <type>U4</type>
+          <comment>Acquisition retry period if previously failed.
+If set to 0, the receiver will never retry a
+startup</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>gridOffset</name>
+          <type>U4</type>
+          <comment>Grid offset relative to GPS start of week</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>onTime</name>
+          <type>U2</type>
+          <comment>Time to stay in Tracking state</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>minAcqTime</name>
+          <type>U2</type>
+          <comment>minimal search time</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>reserved3</name>
+          <type>U1[20]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>extintInactivityMs</name>
+          <type>U4</type>
+          <comment>inactivity time out on EXTINT pin if
+enabled</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PM2</name>
+    <type>Get/set</type>
+    <description>Extended power management configuration</description>
+    <comment>This feature is not supported for either the ADR or FTS products. -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x3B</id>
+      <length>48</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x02 for this version)
+Note: the message version number is the
+same as for protocol versions 18 up to 22;
+please select correct message version
+based on the protocol version supported
+by your firmware.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>maxStartupStateDur</name>
+          <type>U1</type>
+          <comment>Maximum time to spend in Acquisition
+state. If 0: bound disabled.
+(see maxStartupStateDur) (not supported
+in protocol versions 23 to 23.01).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>PSM configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1:3</index>
+              <type>unsigned value</type>
+              <name>optTarget</name>
+              <description>Optimization target
+000 performance (default)
+001 power save
+010 reserved
+011 reserved
+100 reserved
+101 reserved
+110 reserved
+111 reserved</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>extintSel</name>
+              <description>EXTINT pin select
+0 EXTINT0
+1 EXTINT1</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>extintWake</name>
+              <description>EXTINT pin control
+0 disabled
+1 enabled, keep receiver awake as long as selected EXTINT pin is 'high'</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>extintBackup</name>
+              <description>EXTINT pin control
+0 disabled
+1 enabled, force receiver into BACKUP mode when selected EXTINT pin is 'low'</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>extintInactive</name>
+              <description>EXTINT pin control 0 disabled
+1 enabled, force backup in case EXTINT pin is inactive for time longer than extintIncactivityMs</description>
+            </type>
+            <type>
+              <index>8:9</index>
+              <type>unsigned value</type>
+              <name>limitPeakCurr</name>
+              <description>Limit peak current
+00 disabled
+01 enabled, peak current is limited
+10 reserved
+11 reserved</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>waitTimeFix</name>
+              <description>Wait for Timefix
+(see waitTimeFix)
+0 wait for normal fix OK before starting on time
+1 wait for time fix OK before starting on time
+(not supported in protocol versions 23 to 23.01).</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>updateRTC</name>
+              <description>Update real time clock
+(see updateRTC)
+0 do not wake up to update RTC. RTC is updated during normal on-time.
+1 update RTC. The receiver adds extra wake-up cycles to update the RTC.
+(not supported in protocol versions 23 to 23.01, and 32+).</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>updateEPH</name>
+              <description>Update ephemeris
+(see updateEPH)
+0 do not wake up to update Ephemeris data
+1 update Ephemeris. The receiver adds extra wake-up cycles to update the Ephemeris data.</description>
+            </type>
+            <type>
+              <index>13:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>16</index>
+              <type>unsigned value</type>
+              <name>doNotEnterOff</name>
+              <description>Behavior of receiver in case of no fix
+Behavior of receiver in case of no fix (see doNotEnterOff)
+0 receiver enters (Inactive) Awaiting next search state
+1 receiver does not enter (Inactive) Awaiting next search state but keeps trying to acquire a fix
+instead
+(not supported in protocol versions 23 to 23.01).</description>
+            </type>
+            <type>
+              <index>17:18</index>
+              <type>unsigned value</type>
+              <name>mode</name>
+              <description>Mode of operation
+(see mode)
+00 ON/OFF operation (PSMOO) (not supported in protocol versions 23 to 23.01)
+01 cyclic tracking operation (PSMCT)
+10 reserved
+11 reserved</description>
+            </type>
+            <type>
+              <index>19:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>updatePeriod</name>
+          <type>U4</type>
+          <comment>Position update period. If set to 0, the
+receiver will never retry a fix and it will wait
+for external events .</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>searchPeriod</name>
+          <type>U4</type>
+          <comment>Acquisition retry period if previously failed.
+If set to 0, the receiver will never retry a
+startup.
+(not supported in protocol versions 23 to
+23.01).</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>gridOffset</name>
+          <type>U4</type>
+          <comment>Grid offset relative to GPS start of week
+(not supported in protocol versions 23 to
+23.01).</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>onTime</name>
+          <type>U2</type>
+          <comment>Time to stay in Tracking state
+(not supported in protocol versions 23 to
+23.01).</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>minAcqTime</name>
+          <type>U2</type>
+          <comment>Minimal search time</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>reserved3</name>
+          <type>U1[20]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>extintInactivityMs</name>
+          <type>U4</type>
+          <comment>inactivity time out on EXTINT pin if
+enabled</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PMS</name>
+    <type>Get/set</type>
+    <description>Power mode setup</description>
+    <comment>Using UBX-CFG-PMS to set Super-E mode to 1, 2 or 4 Hz navigation rates sets minAcqTime to 180 s instead of the default 300 s in protocol version 23.01.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x86</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>powerSetupValue</name>
+          <type>U1</type>
+          <comment>Power setup value
+0x00 = Full power
+0x01 = Balanced
+0x02 = Interval
+0x03 = Aggressive with 1 Hz
+0x04 = Aggressive with 2 Hz
+0x05 = Aggressive with 4 Hz
+0xFF = Invalid (only when polling)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>period</name>
+          <type>U2</type>
+          <comment>Position update period and search period.
+Recommended minimum period is 10 s,
+although the receiver accepts any value
+bigger than 5 s.
+Only valid when powerSetupValue set to
+Interval, otherwise must be set to '0'.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>onTime</name>
+          <type>U2</type>
+          <comment>Duration of the ON phase, must be smaller
+than the period.
+Only valid when powerSetupValue set to
+Interval, otherwise must be set to '0'.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PRT</name>
+    <type>Poll Request</type>
+    <description>Polls the configuration for one I/O port</description>
+    <comment>Sending this message with a port ID as payload results in having the receiver return the configuration for the specified port.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x00</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>PortID</name>
+          <type>U1</type>
+          <comment>Port identifier number (see the other
+versions of CFG-PRT for valid values)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PRT</name>
+    <type>Get/set</type>
+    <description>Port configuration for UART ports</description>
+    <comment>Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length (see the other versions of CFG-PRT). Output messages from the module contain only one configuration unit. Note that this message can affect baud rate and other transmission parameters. Because there may be messages queued for transmission there may be uncertainty about which protocol applies to such messages. In addition a message currently in transmission may be corrupted by a protocol change. Host data reception parameters may have to be changed to be able to receive future messages, including the acknowledge message resulting from the CFG-PRT message.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x00</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>portID</name>
+          <type>U1</type>
+          <comment>Port identifier number (see Integration
+manual for valid UART port IDs)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>txReady</name>
+          <type>X2</type>
+          <comment>TX ready PIN configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>en</name>
+              <description>Enable TX ready feature for this port</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>pol</name>
+              <description>Polarity
+0 High-active
+1 Low-active</description>
+            </type>
+            <type>
+              <index>2:6</index>
+              <type>unsigned value</type>
+              <name>pin</name>
+              <description>PIO to be used (must not be in use by another function)</description>
+            </type>
+            <type>
+              <index>7:15</index>
+              <type>unsigned value</type>
+              <name>thres</name>
+              <description>Threshold
+The given threshold is multiplied by 8 bytes.
+The TX ready PIN goes active after &gt;= thres*8 bytes are pending for the port and going inactive after
+the last pending bytes have been written to hardware (0-4 bytes before end of stream).
+0x000 no threshold
+0x001 8byte
+0x002 16byte
+...
+0x1FE 4080byte
+0x1FF 4088byte</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>mode</name>
+          <type>X4</type>
+          <comment>A bit mask describing the UART mode</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>unsigned value</type>
+              <name>charLen</name>
+              <description>Character length
+00 5bit (not supported)
+01 6bit (not supported)
+10 7bit (supported only with parity)
+11 8bit</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>9:11</index>
+              <type>unsigned value</type>
+              <name>parity</name>
+              <description>000 Even parity
+001 Odd parity
+10X No parity
+X1X Reserved</description>
+            </type>
+            <type>
+              <index>12:13</index>
+              <type>unsigned value</type>
+              <name>nStopBits</name>
+              <description>Number of Stop bits
+00 1 Stop bit
+01 1.5 Stop bit
+10 2 Stop bit
+11 0.5 Stop bit</description>
+            </type>
+            <type>
+              <index>14:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>baudRate</name>
+          <type>U4</type>
+          <comment>Baud rate in bits/second</comment>
+          <scale>-</scale>
+          <unit>Bits/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>inProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which input protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>inUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>inNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>inRtcm</name>
+              <description>RTCM2 protocol</description>
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>inRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>outProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which output protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>outUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>outNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>outRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Flags bit mask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>extendedTxTimeout</name>
+              <description>Extended TX timeout: if set, the port will time out if allocated TX memory &gt;=4 kB and no activity for 1. 5 s. If not set the port will time out if no activity for 1.5 s regardless on the amount of allocated TX
+memory .</description>
+            </type>
+            <type>
+              <index>2:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PRT</name>
+    <type>Get/set</type>
+    <description>Port configuration for USB port</description>
+    <comment>Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length (see the other versions of CFG-PRT). Output messages from the module contain only one configuration unit.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x00</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>portID</name>
+          <type>U1</type>
+          <comment>Port identifier number (= 3 for USB port)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>txReady</name>
+          <type>X2</type>
+          <comment>TX ready PIN configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>en</name>
+              <description>Enable TX ready feature for this port</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>pol</name>
+              <description>Polarity
+0 High-active
+1 Low-active</description>
+            </type>
+            <type>
+              <index>2:6</index>
+              <type>unsigned value</type>
+              <name>pin</name>
+              <description>PIO to be used (must not be in use by another function)</description>
+            </type>
+            <type>
+              <index>7:15</index>
+              <type>unsigned value</type>
+              <name>thres</name>
+              <description>Threshold
+The given threshold is multiplied by 8 bytes.
+The TX ready PIN goes active after &gt;= thres*8 bytes are pending for the port and going inactive after
+the last pending bytes have been written to hardware (0-4 bytes before end of stream).
+0x000 no threshold
+0x001 8byte
+0x002 16byte
+...
+0x1FE 4080byte
+0x1FF 4088byte</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved2</name>
+          <type>U1[8]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>inProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which input protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>inUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>inNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>inRtcm</name>
+              <description>RTCM2 protocol</description>
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>inRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>outProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which output protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>outUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>outNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>outRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved4</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PRT</name>
+    <type>Get/set</type>
+    <description>Port configuration for SPI port</description>
+    <comment>Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length. Output messages from the module contain only one configuration unit.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x00</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>portID</name>
+          <type>U1</type>
+          <comment>Port identifier number (= 4 for SPI port)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>txReady</name>
+          <type>X2</type>
+          <comment>TX ready PIN configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>en</name>
+              <description>Enable TX ready feature for this port</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>pol</name>
+              <description>Polarity
+0 High-active
+1 Low-active</description>
+            </type>
+            <type>
+              <index>2:6</index>
+              <type>unsigned value</type>
+              <name>pin</name>
+              <description>PIO to be used (must not be in use by another function)</description>
+            </type>
+            <type>
+              <index>7:15</index>
+              <type>unsigned value</type>
+              <name>thres</name>
+              <description>Threshold
+The given threshold is multiplied by 8 bytes.
+The TX ready PIN goes active after &gt;= thres*8 bytes are pending for the port and going inactive after
+the last pending bytes have been written to hardware (0-4 bytes before end of stream).
+0x000 no threshold
+0x001 8byte
+0x002 16byte
+...
+0x1FE 4080byte
+0x1FF 4088byte</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>mode</name>
+          <type>X4</type>
+          <comment>SPI Mode Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1:2</index>
+              <type>unsigned value</type>
+              <name>spiMode</name>
+              <description>00 SPI Mode 0: CPOL = 0, CPHA = 0
+01 SPI Mode 1: CPOL = 0, CPHA = 1
+10 SPI Mode 2: CPOL = 1, CPHA = 0
+11 SPI Mode 3: CPOL = 1, CPHA = 1</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>8:13</index>
+              <type>unsigned value</type>
+              <name>ffCnt</name>
+              <description>Number of bytes containing 0xFF to receive before switching off reception. Range: 0 (mechanism
+off) - 63</description>
+            </type>
+            <type>
+              <index>14:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>inProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which input protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.
+(The bitfield inRtcm3 is not supported in
+protocol versions less than 20)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>inUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>inNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>inRtcm</name>
+              <description>RTCM2 protocol</description>
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>inRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>outProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which output protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.
+(The bitfield outRtcm3 is not supported in
+protocol versions less than 20)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>outUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>outNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>outRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Flags bit mask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>extendedTxTimeout</name>
+              <description>Extended TX timeout: if set, the port will time out if allocated TX memory &gt;=4 kB and no activity for 1. 5 s.</description>
+            </type>
+            <type>
+              <index>2:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PRT</name>
+    <type>Get/set</type>
+    <description>Port configuration for I2C (DDC) port</description>
+    <comment>Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length (see the other versions of CFG-PRT). Output messages from the module contain only one configuration unit.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x00</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>portID</name>
+          <type>U1</type>
+          <comment>Port identifier number (= 0 for I2C (DDC)
+port)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>txReady</name>
+          <type>X2</type>
+          <comment>TX ready PIN configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>en</name>
+              <description>Enable TX ready feature for this port</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>pol</name>
+              <description>Polarity
+0 High-active
+1 Low-active</description>
+            </type>
+            <type>
+              <index>2:6</index>
+              <type>unsigned value</type>
+              <name>pin</name>
+              <description>PIO to be used (must not be in use by another function)</description>
+            </type>
+            <type>
+              <index>7:15</index>
+              <type>unsigned value</type>
+              <name>thres</name>
+              <description>Threshold
+The given threshold is multiplied by 8 bytes.
+The TX ready PIN goes active after &gt;= thres*8 bytes are pending for the port and going inactive after
+the last pending bytes have been written to hardware (0-4 bytes before end of stream).
+0x000 no threshold
+0x001 8byte
+0x002 16byte
+...
+0x1FE 4080byte
+0x1FF 4088byte</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>mode</name>
+          <type>X4</type>
+          <comment>I2C (DDC) Mode Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>unsigned value</type>
+              <name>slaveAddr</name>
+              <description>Slave address
+Range: 0x07 &lt; slaveAddr &lt; 0x78. Bit 0 must be 0</description>
+            </type>
+            <type>
+              <index>8:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>inProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which input protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.
+(The bitfield inRtcm3 is not supported in
+protocol versions less than 20)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>inUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>inNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>inRtcm</name>
+              <description>RTCM2 protocol</description>
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>inRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>outProtoMask</name>
+          <type>X2</type>
+          <comment>A mask describing which output protocols
+are active.
+Each bit of this mask is used for a
+protocol. Through that, multiple protocols
+can be defined on a single port.
+(The bitfield outRtcm3 is not supported in
+protocol versions less than 20)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>outUbx</name>
+              <description>UBX protocol</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>outNmea</name>
+              <description>NMEA protocol</description>
+            </type>
+            <type>
+              <index>2:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>outRtcm3</name>
+              <description>RTCM3 protocol (not supported in protocol versions less than 20)</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Flags bit mask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>extendedTxTimeout</name>
+              <description>Extended TX timeout: if set, the port will time out if allocated TX memory &gt;=4 kB and no activity for 1. 5s.</description>
+            </type>
+            <type>
+              <index>2:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-PWR</name>
+    <type>Set</type>
+    <description>Put receiver in a defined power state</description>
+    <comment>This message is deprecated in protocol versions greater than 17. Use UBX-CFG- RST for GNSS start/stop and UBX-RXM-PMREQ for software backup. -</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x57</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>state</name>
+          <type>U4</type>
+          <comment>Enter system state
+0x52554E20: GNSS running
+0x53544F50: GNSS stopped
+0x42434B50: Software backup. USB
+interface will be disabled, other wakeup
+source is needed.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-RATE</name>
+    <type>Get/set</type>
+    <description>Navigation/measurement rate settings</description>
+    <comment>This message allows the user to alter the rate at which navigation solutions (and the measurements that they depend on) are generated by the receiver. The calculation of the navigation solution will always be aligned to the top of a second zero (first second of the week) of the configured reference time system. (Navigation period is an integer multiple of the measurement period in protocol versions greater than 17).  Each measurement triggers the measurements generation and, if available,  raw data output.  The navRate value defines that every nth measurement triggers a navigation  epoch.  The update rate has a direct influence on the power consumption. The more  fixes that are required, the more CPU power and communication resources are  required.  For most applications a 1 Hz update rate would be sufficient.  When using power save mode, measurement and navigation rate can differ  from the values configured here.  See Measurement and navigation rate with power save mode for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x08</id>
+      <length>6</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>measRate</name>
+          <type>U2</type>
+          <comment>The elapsed time between GNSS
+measurements, which defines the rate, e.
+g. 100 ms =&gt; 10 Hz, 1000 ms =&gt; 1 Hz,
+10000 ms =&gt; 0.1 Hz. Measurement rate
+should be greater than or equal to 25 ms.
+(Measurement rate should be greater
+than or equal to 50 ms in protocol versions
+less than 24).</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>navRate</name>
+          <type>U2</type>
+          <comment>The ratio between the number of
+measurements and the number of
+navigation solutions, e.g. 5 means five
+measurements for every navigation
+solution. Maximum value is 127. (This
+parameter is ignored and the navRate is
+fixed to 1 in protocol versions less than 18).</comment>
+          <scale>-</scale>
+          <unit>cycles</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>timeRef</name>
+          <type>U2</type>
+          <comment>The time system to which measurements
+are aligned:
+0: UTC time
+1: GPS time
+2: GLONASS time (not supported in
+protocol versions less than 18)
+3: BeiDou time (not supported in protocol
+versions less than 18)
+4: Galileo time (not supported in protocol
+versions less than 18)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-RINV</name>
+    <type>Get/set</type>
+    <description>Contents of remote inventory</description>
+    <comment>If N is greater than 30, the excess bytes are discarded.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x34</id>
+      <length>1 + 1*N</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>dump</name>
+              <description>Dump data at startup. Does not work if flag binary is set.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>binary</name>
+              <description>Data is binary.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block name="N" type="repeated">
+          <block>
+            <offset>1 + 1*N</offset>
+            <name>data</name>
+            <type>U1</type>
+            <comment>Data to store/stored in remote inventory.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-RST</name>
+    <type>Command</type>
+    <description>Reset receiver / Clear backup data structures</description>
+    <comment>Do not expect this message to be acknowledged by the receiver.  Newer FW version will not acknowledge this message at all.  Older FW version will acknowledge this message but the acknowledge may not  be sent completely before the receiver is reset.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x04</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>navBbrMask</name>
+          <type>X2</type>
+          <comment>BBR sections to clear. The following
+special sets apply:
+0x0000 Hot start
+0x0001 Warm start
+0xFFFF Cold start</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>eph</name>
+              <description>Ephemeris</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>alm</name>
+              <description>Almanac</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>health</name>
+              <description>Health</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>klob</name>
+              <description>Klobuchar parameters</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>pos</name>
+              <description>Position</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>clkd</name>
+              <description>Clock drift</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>osc</name>
+              <description>Oscillator parameter</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>utc</name>
+              <description>UTC correction + GPS leap seconds parameters</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>rtc</name>
+              <description>RTC</description>
+            </type>
+            <type>
+              <index>9:14</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>15</index>
+              <type>unsigned value</type>
+              <name>aop</name>
+              <description>Autonomous orbit parameters</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>resetMode</name>
+          <type>U1</type>
+          <comment>Reset Type
+0x00 = Hardware reset (watchdog)
+immediately
+0x01 = Controlled software reset
+0x02 = Controlled software reset (GNSS
+only)
+0x04 = Hardware reset (watchdog) after
+shutdown
+0x08 = Controlled GNSS stop
+0x09 = Controlled GNSS start</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-RXM</name>
+    <type>Get/set</type>
+    <description>RXM configuration</description>
+    <comment>For a detailed description see section Power management in Integration manual Note that Power save mode cannot be selected when the receiver is configured to process GLONASS signals (using UBX-CFG-GNSS).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16 and 17</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x11</id>
+      <length>2</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>lpMode</name>
+          <type>U1</type>
+          <comment>Low power mode
+0: Continuous mode
+1: Power save mode
+4: Continuous mode
+Note that for receivers with protocol
+versions larger or equal to 14, both Low
+power mode settings 0 and 4 configure
+the receiver to Continuous mode.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-RXM</name>
+    <type>Get/set</type>
+    <description>RXM configuration</description>
+    <comment>For a detailed description see section Power Management.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x11</id>
+      <length>2</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>lpMode</name>
+          <type>U1</type>
+          <comment>Low power mode
+0: Continuous mode
+1: Power save mode
+4: Continuous mode</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-SBAS</name>
+    <type>Get/set</type>
+    <description>SBAS configuration</description>
+    <comment>This message configures the SBAS receiver subsystem (i.e. WAAS, EGNOS, MSAS). See the SBAS configuration settings description for a detailed description of how these settings affect receiver operation.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x16</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>mode</name>
+          <type>X1</type>
+          <comment>SBAS mode</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>enabled</name>
+              <description>SBAS enabled (1) / disabled (0) - This field is deprecated; use UBX-CFG-GNSS to enable/disable SBAS
+operation</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>test</name>
+              <description>SBAS testbed: Use data anyhow (1) / Ignore data when in test mode (SBAS msg 0)</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>usage</name>
+          <type>X1</type>
+          <comment>SBAS usage</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>range</name>
+              <description>Use SBAS GEOs as a ranging source (for navigation)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>diffCorr</name>
+              <description>Use SBAS differential corrections</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>integrity</name>
+              <description>Use SBAS integrity information. If enabled, the receiver will only use GPS satellites for which
+integrity information is available.</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>maxSBAS</name>
+          <type>U1</type>
+          <comment>Maximum number of SBAS prioritized
+tracking channels (valid range: 0 - 3) to
+use (obsolete and superseded by UBX-
+CFG-GNSS in protocol versions 14+).</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>scanmode2</name>
+          <type>X1</type>
+          <comment>Continuation of scanmode bitmask below</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>scanmode1</name>
+          <type>X4</type>
+          <comment>Which SBAS PRN numbers to search for
+(bitmask).
+If all bits are set to zero, auto-scan (i.e. all
+valid PRNs) are searched.
+Every bit corresponds to a PRN number.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-SLAS</name>
+    <type>Get/set</type>
+    <description>SLAS configuration</description>
+    <comment>This message configures the QZSS SLAS (Sub-meter Level Augmentation System). See the SLAS Configuration Settings Description for a detailed description of how these settings affect receiver operation. To apply SLAS corrections, QZSS operation and L1S signal tracking must be enabled see UBX-CFG-GNSS</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 19.2 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x8D</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>mode</name>
+          <type>X1</type>
+          <comment>SLAS Mode</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>enabled</name>
+              <description>Apply QZSS SLAS DGNSS corrections: Enabled (1) / Disabled (0)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>test</name>
+              <description>Use QZSS SLAS data when in test mode (SLAS msg 0): Use data anyhow (1) / Ignore data when in
+Test Mode (0)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>raim</name>
+              <description>Raim out measurements that are not corrected by QZSS SLAS, if at least 5 measurements are
+corrected: Enabled (1) / Disabled (0)</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-SMGR</name>
+    <type>Get/set</type>
+    <description>Synchronization manager configuration</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x62</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>minGNSSFix</name>
+          <type>U1</type>
+          <comment>Minimum number of GNSS fixes before we
+commit to use it as a source</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>maxFreqChangeRate</name>
+          <type>U2</type>
+          <comment>Maximum frequency change rate during
+disciplining. Must not exceed 30ppb/s</comment>
+          <scale>-</scale>
+          <unit>ppb/s</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>maxPhaseCorrRate</name>
+          <type>U2</type>
+          <comment>Maximum phase correction rate in
+coherent time pulse mode.
+For maximum phase correction rate in
+corrective time pulse mode see
+maxSlewRate.
+Note that in coherent time pulse mode
+phase correction is achieved by intentional
+frequency offset. Allowing for a high
+phase correction rate can result in large
+intentional frequency offset. Must not
+exceed 100ns/s</comment>
+          <scale>-</scale>
+          <unit>ns/s</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>freqTolerance</name>
+          <type>U2</type>
+          <comment>Limit of possible deviation from nominal
+before UBX-TIM-TOS indicates that
+frequency is out of tolerance</comment>
+          <scale>-</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>timeTolerance</name>
+          <type>U2</type>
+          <comment>Limit of possible deviation from nominal
+before UBX-TIM-TOS indicates that time
+pulse is out of tolerance</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>messageCfg</name>
+          <type>X2</type>
+          <comment>Sync manager message configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>measInternal</name>
+              <description>1 = report the estimated offset of the internal oscillator based on the oscillator model</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>measGNSS</name>
+              <description>1 = report the internal oscillator's offset relative to GNSS</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>measEXTINT0</name>
+              <description>1 = report the internal oscillator's offset relative to the source on EXTINT0</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>measEXTINT1</name>
+              <description>1 = report the internal oscillator's offset relative to the source on EXTINT1</description>
+            </type>
+            <type>
+              <index>4:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>maxSlewRate</name>
+          <type>U2</type>
+          <comment>Maximum slew rate, the maximum time
+correction that shall be applied between
+locked pulses in corrective time pulse
+mode.
+To have no limit on the slew rate, set the
+flag disableMaxSlewRate to 1
+For maximum phase correction rate in
+coherent time pulse mode see
+maxPhaseCorrRate.</comment>
+          <scale>-</scale>
+          <unit>us/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>disableInternal</name>
+              <description>1 = disable disciplining of the internal oscillator</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>disableExternal</name>
+              <description>1 = disable disciplining of the external oscillator</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>preferenceMode</name>
+              <description>Reference selection preference 0 - best frequency accuracy
+1 - best phase accuracy</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>enableGNSS</name>
+              <description>1 = enable use of GNSS as synchronization source</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>enableEXTINT0</name>
+              <description>1 = enable use of EXTINT0 as synchronization source</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>enableEXTINT1</name>
+              <description>1 = enable use of EXTINT1 as synchronization source</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>enableHostMeasInt</name>
+              <description>1 = enable use of host measurements on the internal oscillator as synchronization source Measurements made by the host must be sent to the receiver using a UBX-TIM-SMEAS-DATA0
+message.</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>enableHostMeasExt</name>
+              <description>1 = enable use of host measurements on the external oscillator as synchronization source Measurements made by the host must be sent to the receiver using a UBX-TIM-SMEAS-DATA0
+message.</description>
+            </type>
+            <type>
+              <index>8:9</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>useAnyFix</name>
+              <description>0 - use over-determined navigation solutions only
+1 - use any fix</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>disableMaxSlewRate</name>
+              <description>0 - use the value in the field maxSlewRate for maximum time correction in corrective time pulse mode
+1 - don't use the value in the field maxSlewRate</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>issueFreqWarning</name>
+              <description>1 = issue a warning (via UBX-TIM-TOS flag) when frequency uncertainty exceeds freqTolerance</description>
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>issueTimeWarning</name>
+              <description>1 = issue a warning (via UBX-TIM-TOS flag) when time uncertainty exceeds timeTolerance</description>
+            </type>
+            <type>
+              <index>14:15</index>
+              <type>unsigned value</type>
+              <name>TPCoherent</name>
+              <description>Control time pulse coherency
+0 - Coherent pulses. Time phase offsets will be corrected gradually by varying the GNSS oscillator
+rate within frequency tolerance limits. There will always be the correct number of GNSS oscillator
+cycles between time pulses. Given tight limits this may take a long time
+1 - Non-coherent pulses. In this mode the receiver will correct time phase offsets as quickly as
+allowed by the specified maximum slew rate, in which case there may not be the expected number of
+GNSS oscillator cycles between time pulses.
+2 - Post-initialization coherent pulses. The receiver will run in non-coherent mode as described above
+until the pulse timing has been corrected and PLL is active on the internal oscillator, but will then
+switch to coherent pulse mode.</description>
+            </type>
+            <type>
+              <index>16</index>
+              <type>unsigned value</type>
+              <name>disableOffset</name>
+              <description>1 = disable automatic storage of oscillator offset</description>
+            </type>
+            <type>
+              <index>17:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TMODE2</name>
+    <type>Get/set</type>
+    <description>Time mode settings 2</description>
+    <comment>This message is available only for timing receivers See the Time Mode Description for details. This message replaces the deprecated UBX-CFG-TMODE message.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync or Time Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x3D</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>timeMode</name>
+          <type>U1</type>
+          <comment>Time Transfer Mode:
+0 Disabled
+1 Survey In
+2 Fixed Mode (true position information
+required)
+3-255 Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Time mode flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>lla</name>
+              <description>Position is given in LAT/LON/ALT (default is ECEF)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>altInv</name>
+              <description>Altitude is not valid, in case lla was set</description>
+            </type>
+            <type>
+              <index>2:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ecefXOrLat</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF X coordinate or latitude,
+depending on flags above</comment>
+          <scale>-</scale>
+          <unit>cm_or_deg*1e-7</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefYOrLon</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Y coordinate or longitude,
+depending on flags above</comment>
+          <scale>-</scale>
+          <unit>cm_or_deg*1e-7</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefZOrAlt</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Z coordinate or altitude,
+depending on flags above</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>fixedPosAcc</name>
+          <type>U4</type>
+          <comment>Fixed position 3D accuracy</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>svinMinDur</name>
+          <type>U4</type>
+          <comment>Survey-in minimum duration</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>svinAccLimit</name>
+          <type>U4</type>
+          <comment>Survey-in position accuracy limit</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TMODE3</name>
+    <type>Get/set</type>
+    <description>Time mode settings 3</description>
+    <comment>Configures the receiver to be in Time Mode. The position referred to in this message is that of the Antenna Reference Point (ARP). See the Time Mode Description for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20, 20.01, 20.1, 20.2 and 20.3 (only with High Precision GNSS products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x71</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Receiver mode flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:7</index>
+              <type>unsigned value</type>
+              <name>mode</name>
+              <description>Receiver Mode:
+0 Disabled
+1 Survey In
+2 Fixed Mode (true ARP position information required)
+3-255 Reserved</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>lla</name>
+              <description>Position is given in LAT/LON/ALT (default is ECEF)</description>
+            </type>
+            <type>
+              <index>9:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ecefXOrLat</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF X coordinate (or latitude) of
+the ARP position, depending on flags
+above</comment>
+          <scale>-</scale>
+          <unit>cm_or_deg*1e-7</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefYOrLon</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Y coordinate (or longitude)
+of the ARP position, depending on flags
+above</comment>
+          <scale>-</scale>
+          <unit>cm_or_deg*1e-7</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefZOrAlt</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Z coordinate (or altitude) of
+the ARP position, depending on flags
+above</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>ecefXOrLatHP</name>
+          <type>I1</type>
+          <comment>High-precision WGS84 ECEF X coordinate
+(or latitude) of the ARP position,
+depending on flags above. Must be in the
+range -99..+99.
+The precise WGS84 ECEF X coordinate in
+units of cm, or the precise WGS84 ECEF
+latitude in units of 1e-7 degrees, is given by
+ecefXOrLat + (ecefXOrLatHP * 1e-2)</comment>
+          <scale>-</scale>
+          <unit>0.1_mm_or_deg*1e-9</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>ecefYOrLonHP</name>
+          <type>I1</type>
+          <comment>High-precision WGS84 ECEF Y coordinate
+(or longitude) of the ARP position,
+depending on flags above. Must be in the
+range -99..+99.
+The precise WGS84 ECEF Y coordinate in
+units of cm, or the precise WGS84 ECEF
+longitude in units of 1e-7 degrees, is given
+by
+ecefYOrLon + (ecefYOrLonHP * 1e-2)</comment>
+          <scale>-</scale>
+          <unit>0.1_mm_or_deg*1e-9</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>ecefZOrAltHP</name>
+          <type>I1</type>
+          <comment>High-precision WGS84 ECEF Z coordinate
+(or altitude) of the ARP position,
+depending on flags above. Must be in the
+range -99..+99.
+The precise WGS84 ECEF Z coordinate, or
+altitude coordinate, in units of cm is given
+by
+ecefZOrAlt + (ecefZOrAltHP * 1e-2)</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>19</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>fixedPosAcc</name>
+          <type>U4</type>
+          <comment>Fixed position 3D accuracy</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>svinMinDur</name>
+          <type>U4</type>
+          <comment>Survey-in minimum duration</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>svinAccLimit</name>
+          <type>U4</type>
+          <comment>Survey-in position accuracy limit</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved3</name>
+          <type>U1[8]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TP5</name>
+    <type>Poll Request</type>
+    <description>Poll time pulse parameters for time pulse 0</description>
+    <comment>Sending this (empty / no-payload) message to the receiver results in the receiver returning a message of type UBX-CFG-TP5 with a payload as defined below for timepulse 0.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3 and 22</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x31</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TP5</name>
+    <type>Poll Request</type>
+    <description>Poll time pulse parameters</description>
+    <comment>Sending this message to the receiver results in the receiver returning a message of type UBX-CFG-TP5 with a payload as defined below for the specified time pulse.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3 and 22</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x31</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>tpIdx</name>
+          <type>U1</type>
+          <comment>Time pulse selection (0 = TIMEPULSE, 1 =
+TIMEPULSE2)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TP5</name>
+    <type>Get/set</type>
+    <description>Time pulse parameters</description>
+    <comment>This message is used to get/set time pulse parameters. For more information see section Time pulse.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 15</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x31</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>tpIdx</name>
+          <type>U1</type>
+          <comment>Time pulse selection (0 = TIMEPULSE, 1 =
+TIMEPULSE2)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>antCableDelay</name>
+          <type>I2</type>
+          <comment>Antenna cable delay</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>rfGroupDelay</name>
+          <type>I2</type>
+          <comment>RF group delay</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>freqPeriod</name>
+          <type>U4</type>
+          <comment>Frequency or period time, depending on
+setting of bit 'isFreq'</comment>
+          <scale>-</scale>
+          <unit>Hz_or_us</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>freqPeriodLock</name>
+          <type>U4</type>
+          <comment>Frequency or period time when locked to
+GPS time, only used if 'lockedOtherSet' is
+set</comment>
+          <scale>-</scale>
+          <unit>Hz_or_us</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>pulseLenRatio</name>
+          <type>U4</type>
+          <comment>Pulse length or duty cycle, depending on
+'isLength'</comment>
+          <scale>-</scale>
+          <unit>us_or_2^-32</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>pulseLenRatioLock</name>
+          <type>U4</type>
+          <comment>Pulse length or duty cycle when locked to
+GPS time, only used if 'lockedOtherSet' is
+set</comment>
+          <scale>-</scale>
+          <unit>us_or_2^-32</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>userConfigDelay</name>
+          <type>I4</type>
+          <comment>User-configurable time pulse delay</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>Configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>active</name>
+              <description>if set enable time pulse; if pin assigned to another function, other function takes precedence</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>lockGpsFreq</name>
+              <description>if set synchronize time pulse to GPS as soon as GPS time is valid, otherwise use local clock</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>lockedOtherSet</name>
+              <description>if set use 'freqPeriodLock' and 'pulseLenRatioLock' as soon as GPS time is valid and 'freqPeriod' and 'pulseLenRatio' if GPS time is invalid,
+if flag is cleared 'freqPeriod' and 'pulseLenRatio' used regardless of GPS time</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>isFreq</name>
+              <description>if set 'freqPeriodLock' and 'freqPeriod' interpreted as frequency, otherwise interpreted as period</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>isLength</name>
+              <description>if set 'pulseLenRatioLock' and 'pulseLenRatio' interpreted as pulse length, otherwise interpreted as
+duty cycle</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>alignToTow</name>
+              <description>align pulse to top of second (period time must be integer fraction of 1s)</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>polarity</name>
+              <description>pulse polarity:
+0 = falling edge at top of second
+1 = rising edge at top of second</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>gridUtcGps</name>
+              <description>timegrid to use:
+0 = UTC
+1 = GPS</description>
+            </type>
+            <type>
+              <index>8:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TP5</name>
+    <type>Get/set</type>
+    <description>Time pulse parameters</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x31</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>tpIdx</name>
+          <type>U1</type>
+          <comment>Time pulse selection (0 = TIMEPULSE, 1 =
+TIMEPULSE2)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>antCableDelay</name>
+          <type>I2</type>
+          <comment>Antenna cable delay</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>rfGroupDelay</name>
+          <type>I2</type>
+          <comment>RF group delay</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>freqPeriod</name>
+          <type>U4</type>
+          <comment>Frequency or period time, depending on
+setting of bit 'isFreq'</comment>
+          <scale>-</scale>
+          <unit>Hz_or_us</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>freqPeriodLock</name>
+          <type>U4</type>
+          <comment>Frequency or period time when locked to
+GNSS time, only used if 'lockedOtherSet'
+is set</comment>
+          <scale>-</scale>
+          <unit>Hz_or_us</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>pulseLenRatio</name>
+          <type>U4</type>
+          <comment>Pulse length or duty cycle, depending on
+'isLength'</comment>
+          <scale>-</scale>
+          <unit>us_or_2^-32</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>pulseLenRatioLock</name>
+          <type>U4</type>
+          <comment>Pulse length or duty cycle when locked to
+GNSS time, only used if 'lockedOtherSet'
+is set</comment>
+          <scale>-</scale>
+          <unit>us_or_2^-32</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>userConfigDelay</name>
+          <type>I4</type>
+          <comment>User-configurable time pulse delay</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>Configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>active</name>
+              <description>If set enable time pulse; if pin assigned to another function, other function takes precedence.
+Must be set for FTS variant.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>lockGnssFreq</name>
+              <description>If set, synchronize time pulse to GNSS as soon as GNSS time is valid. If not set, or before GNSS time
+is valid, use local clock.
+This flag is ignored by the FTS product variant; in this case the receiver always locks to the best
+available time/frequency reference (which is not necessarily GNSS).
+This flag can be unset only in Timing product variants.</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>lockedOtherSet</name>
+              <description>If set the receiver switches between the timepulse settings given by 'freqPeriodLocked' &amp; 'pulseLenLocked' and those given by 'freqPeriod' &amp; 'pulseLen'. The 'Locked' settings are used where
+the receiver has an accurate sense of time. For non-FTS products, this occurs when GNSS solution
+with a reliable time is available, but for FTS products the setting syncMode field governs behavior. In
+all cases, the receiver only uses 'freqPeriod' &amp; 'pulseLen' when the flag is unset.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>isFreq</name>
+              <description>If set 'freqPeriodLock' and 'freqPeriod' are interpreted as frequency, otherwise interpreted as period.</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>isLength</name>
+              <description>If set 'pulseLenRatioLock' and 'pulseLenRatio' interpreted as pulse length, otherwise interpreted as
+duty cycle.</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>alignToTow</name>
+              <description>Align pulse to top of second (period time must be integer fraction of 1s).
+Also set 'lockGnssFreq' to use this feature.
+This flag is ignored by the FTS product variant; it is assumed to be always set (as is lockGnssFreq).
+Set maxSlewRate and maxPhaseCorrRate fields of UBX-CFG-SMGR to 0 to disable alignment.</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>polarity</name>
+              <description>Pulse polarity:
+0: falling edge at top of second
+1: rising edge at top of second</description>
+            </type>
+            <type>
+              <index>7:10</index>
+              <type>unsigned value</type>
+              <name>gridUtcGnss</name>
+              <description>Timegrid to use:
+0: UTC
+1: GPS
+2: GLONASS
+3: BeiDou
+4: Galileo (not supported in protocol versions less than 18)
+This flag is only relevant if 'lockGnssFreq' and 'alignToTow' are set.
+Note that configured GNSS time is estimated by the receiver if locked to any GNSS system. If the
+receiver has a valid GNSS fix it will attempt to steer the TP to the specified time grid even if the
+specified time is not based on information from the constellation's satellites. To ensure timing based
+purely on a given GNSS, restrict the supported constellations in UBX-CFG-GNSS.</description>
+            </type>
+            <type>
+              <index>11:13</index>
+              <type>unsigned value</type>
+              <name>syncMode</name>
+              <description>Sync Manager lock mode to use:
+0: switch to 'freqPeriodLock' and 'pulseLenRatioLock' as soon as Sync Manager has an accurate
+time, never switch back to 'freqPeriod' and 'pulseLenRatio'
+1: switch to 'freqPeriodLock' and 'pulseLenRatioLock' as soon as Sync Manager has an accurate
+time, and switch back to 'freqPeriod' and 'pulseLenRatio' as soon as time gets inaccurate
+This field is only relevant for the FTS product variant.
+This field is only relevant if the flag 'lockedOtherSet' is set.</description>
+            </type>
+            <type>
+              <index>14:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-TXSLOT</name>
+    <type>Set</type>
+    <description>TX buffer time slots configuration</description>
+    <comment>This message configures how transmit time slots are defined for the receiver interfaces. These time slots are relative to the chosen time pulse. A receiver that supports this message offers 3 time slots: nr. 0, 1 and 2. These time pulses follow each other and their associated priorities decrease in this order. The end of each can be specified in this message, the beginning is when the circularly previous slot ends (i.e. slot 0 starts when slot 2 finishes).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x53</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>enable</name>
+          <type>X1</type>
+          <comment>Bitfield of ports for which the slots are
+enabled.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>DDC</name>
+              <description>DDC/I2C</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>UART1</name>
+              <description>UART 1</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>UART2</name>
+              <description>UART 2</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>USB</name>
+              <description>USB</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>SPI</name>
+              <description>SPI</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>refTp</name>
+          <type>U1</type>
+          <comment>Reference timepulse source
+0 - Timepulse
+1 - Timepulse 2</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="3" type="repeated">
+          <block>
+            <offset>4 + 4*N</offset>
+            <name>end</name>
+            <type>U4</type>
+            <comment>End of timeslot in milliseconds after time
+pulse</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-USB</name>
+    <type>Get/set</type>
+    <description>USB configuration</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x1B</id>
+      <length>108</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>vendorID</name>
+          <type>U2</type>
+          <comment>Vendor ID. This field shall only be set to
+registered Vendor IDs. Changing this field
+requires special Host drivers.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>productID</name>
+          <type>U2</type>
+          <comment>Product ID. Changing this field requires
+special Host drivers.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>powerConsumption</name>
+          <type>U2</type>
+          <comment>Power consumed by the device</comment>
+          <scale>-</scale>
+          <unit>mA</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>various configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>reEnum</name>
+              <description>force re-enumeration</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>powerMode</name>
+              <description>self-powered (1), bus-powered (0)</description>
+            </type>
+            <type>
+              <index>2:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>vendorString</name>
+          <type>CH[32]</type>
+          <comment>String containing the vendor name. 32
+ASCII bytes including 0-termination.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>productString</name>
+          <type>CH[32]</type>
+          <comment>String containing the product name. 32
+ASCII bytes including 0-termination.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>76</offset>
+          <name>serialNumber</name>
+          <type>CH[32]</type>
+          <comment>String containing the serial number. 32
+ASCII bytes including 0-termination.
+Changing the String fields requires special
+Host drivers.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-ESF-INS</name>
+    <type>Periodic/Polled</type>
+    <description>Vehicle dynamics information</description>
+    <comment>This message outputs information about the vehicle dynamics. For ADR products (in protocol versions less than 19.2), the output dynamics information (angular rates and accelerations) is expressed with respect to the vehicle-frame. More information can be found in the ADR Navigation Output section. For ADR products, the output dynamics information (angular rates and accelerations) is expressed with respect to the vehicle-frame. More information can be found in the ADR Navigation Output section. For UDR products, the output dynamics information (angular rates and accelerations) are expressed with respect to the body-frame. More information can be found in the UDR Navigation Output section.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x10</class>
+      <id>0x15</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>bitfield0</name>
+          <type>U4</type>
+          <comment>Bitfield</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:7</index>
+              <type>unsigned value</type>
+              <name>version</name>
+              <description>Message version (0x01 for this version)</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>xAngRateValid</name>
+              <description>Compensated x-axis angular rate data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>9</index>
+              <type>unsigned value</type>
+              <name>yAngRateValid</name>
+              <description>Compensated y-axis angular rate data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>zAngRateValid</name>
+              <description>Compensated z-axis angular rate data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>xAccelValid</name>
+              <description>Compensated x-axis acceleration data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>yAccelValid</name>
+              <description>Compensated y-axis acceleration data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>zAccelValid</name>
+              <description>Compensated z-axis acceleration data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>14:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>xAngRate</name>
+          <type>I4</type>
+          <comment>Compensated x-axis angular rate.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>yAngRate</name>
+          <type>I4</type>
+          <comment>Compensated y-axis angular rate.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>zAngRate</name>
+          <type>I4</type>
+          <comment>Compensated z-axis angular rate.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>xAccel</name>
+          <type>I4</type>
+          <comment>Compensated x-axis acceleration (gravity-
+free).</comment>
+          <scale>1e-2</scale>
+          <unit>m/s^2</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>yAccel</name>
+          <type>I4</type>
+          <comment>Compensated y-axis acceleration (gravity-
+free).</comment>
+          <scale>1e-2</scale>
+          <unit>m/s^2</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>zAccel</name>
+          <type>I4</type>
+          <comment>Compensated z-axis acceleration (gravity-
+free).</comment>
+          <scale>1e-2</scale>
+          <unit>m/s^2</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-ESF-MEAS</name>
+    <type>Input/Output</type>
+    <description>External sensor fusion measurements</description>
+    <comment>Possible data types for the data field are described in the ESF Measurement Data section.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16 and 17 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x10</class>
+      <id>0x02</id>
+      <length>(8 + 4*numMeas) or (12 + 4*numMeas)</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>timeTag</name>
+          <type>U4</type>
+          <comment>Time tag of measurement generated by
+external sensor</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>Flags. Set all unused bits to zero.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:1</index>
+              <type>unsigned value</type>
+              <name>timeMarkSent</name>
+              <description>Time mark signal was supplied just prior to sending this message: 0 = none, 1 = on Ext0, 2 = on Ext1</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>timeMarkEdge</name>
+              <description>Trigger on rising (0) or falling (1) edge of time mark signal</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>calibTtagValid</name>
+              <description>Calibration time tag available. Always set to zero.</description>
+            </type>
+            <type>
+              <index>4:10</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>11:15</index>
+              <type>unsigned value</type>
+              <name>numMeas</name>
+              <description>Number of measurements contained in this message (optional, can be obtained from message size)</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>id</name>
+          <type>U2</type>
+          <comment>Identification number of data provider</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numMeas" type="repeated">
+          <block>
+            <offset>8 + 4*N</offset>
+            <name>data</name>
+            <type>X4</type>
+            <comment>data</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:23</index>
+                <type>unsigned value</type>
+                <name>dataField</name>
+                <description>Data</description>
+              </type>
+              <type>
+                <index>24:29</index>
+                <type>unsigned value</type>
+                <name>dataType</name>
+                <description>Type of data (0 = no data; 1..63 = data type)</description>
+              </type>
+              <type>
+                <index>30:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+        <block type="optional">
+          <block>
+            <offset>8+4*numMeas</offset>
+            <name>calibTtag</name>
+            <type>U4</type>
+            <comment>Receiver local time calibrated.
+This field must not be supplied when
+calibTtagValid is set to 0.</comment>
+            <scale>-</scale>
+            <unit>ms</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-ESF-RAW</name>
+    <type>Output</type>
+    <description>Raw sensor measurements</description>
+    <comment>The message contains measurements from the active inertial sensors connected to the GNSS chip. Possible data types for the data field are accelerometer, gyroscope and temperature readings as described in the ESF Measurement Data section. Note that the rate selected in UBX-CFG-MSG is not respected. If a positive rate is selected then all raw measurements will be output. See also Raw Sensor Measurement Data.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16 and 17 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x10</class>
+      <id>0x03</id>
+      <length>4 + 8*N</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="N" type="repeated">
+          <block>
+            <offset>4 + 8*N</offset>
+            <name>data</name>
+            <type>X4</type>
+            <comment>data
+Same as in UBX-ESF-MEAS</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:23</index>
+                <type>unsigned value</type>
+                <name>dataField</name>
+                <description>data</description>
+              </type>
+              <type>
+                <index>24:31</index>
+                <type>unsigned value</type>
+                <name>dataType</name>
+                <description>type of data (0 = no data; 1..255 = data type)</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>8 + 8*N</offset>
+            <name>sTtag</name>
+            <type>U4</type>
+            <comment>sensor time tag</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-ESF-STATUS</name>
+    <type>Periodic/Polled</type>
+    <description>External sensor fusion status</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16 and 17 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x10</class>
+      <id>0x10</id>
+      <length>16 + 4*numSens</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x02 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[7]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>fusionMode</name>
+          <type>U1</type>
+          <comment>Fusion mode:
+0: Initialization mode: receiver is
+initializing some unknown values required
+for doing sensor fusion
+1: Fusion mode: GNSS and sensor data are
+used for navigation solution computation
+2: Suspended fusion mode: sensor fusion
+is temporarily disabled due to e.g. invalid
+sensor data or detected ferry
+3: Disabled fusion mode: sensor fusion is
+permanently disabled until receiver reset
+due e.g. to sensor error
+More details can be found in the Fusion
+Modes section.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>numSens</name>
+          <type>U1</type>
+          <comment>Number of sensors</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSens" type="repeated">
+          <block>
+            <offset>16 + 4*N</offset>
+            <name>sensStatus1</name>
+            <type>X1</type>
+            <comment>Sensor status, part 1</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:5</index>
+                <type>unsigned value</type>
+                <name>type</name>
+                <description>Sensor data type. See section Sensor data types in the Integration manual for details.</description>
+              </type>
+              <type>
+                <index>6</index>
+                <type>unsigned value</type>
+                <name>used</name>
+                <description>If set, sensor data is used for the current sensor fusion solution.</description>
+              </type>
+              <type>
+                <index>7</index>
+                <type>unsigned value</type>
+                <name>ready</name>
+                <description>If set, sensor is set up (configuration is available or not required) but not used for computing the
+current sensor fusion solution.</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>17 + 4*N</offset>
+            <name>sensStatus2</name>
+            <type>X1</type>
+            <comment>Sensor status, part 2</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:1</index>
+                <type>unsigned value</type>
+                <name>calibStatus</name>
+                <description>00: Sensor is not calibrated
+01: Sensor is calibrating
+10/11: Sensor is calibrated
+Good dead reckoning performance is only possible when all used sensors are calibrated. Depending
+on the quality of the GNSS signals and the sensor data, the sensors may take a longer time to get
+calibrated.</description>
+              </type>
+              <type>
+                <index>2:3</index>
+                <type>unsigned value</type>
+                <name>timeStatus</name>
+                <description>00: No data
+01: Reception of the first byte used to tag the measurement
+10: Event input used to tag the measurement
+11: Time tag provided with the data</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>18 + 4*N</offset>
+            <name>freq</name>
+            <type>U1</type>
+            <comment>Observation frequency</comment>
+            <scale>-</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>19 + 4*N</offset>
+            <name>faults</name>
+            <type>X1</type>
+            <comment>Sensor faults</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>badMeas</name>
+                <description>Bad measurements detected</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>badTTag</name>
+                <description>Bad measurement time-tags detected</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>missingMeas</name>
+                <description>Missing or time-misaligned measurements detected</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>unsigned value</type>
+                <name>noisyMeas</name>
+                <description>High measurement noise-level detected</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-HNR-INS</name>
+    <type>Periodic/Polled</type>
+    <description>Vehicle dynamics information</description>
+    <comment>This message outputs high rate information about vehicle dynamics computed by the Inertial Navigation System (INS) during ESF-based navigation. For ADR products (in protocol versions less than 19.2), the output dynamics information (angular rates and accelerations) is expressed with respect to the vehicle-frame. More information can be found in the ADR Navigation Output section. For UDR products, the output dynamics information (angular rates and accelerations) is expressed with respect to the body-frame. More information can be found in the UDR Navigation Output section. For ADR products, the output dynamics information (angular rates and accelerations) is expressed with respect to the vehicle-frame. More information can be found in the ADR Navigation Output section.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x28</class>
+      <id>0x02</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>bitfield0</name>
+          <type>X4</type>
+          <comment>Bitfield</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:7</index>
+              <type>unsigned value</type>
+              <name>version</name>
+              <description>Message version (0x00 for this version)</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>xAngRateValid</name>
+              <description>Compensated x-axis angular rate data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>9</index>
+              <type>unsigned value</type>
+              <name>yAngRateValid</name>
+              <description>Compensated y-axis angular rate data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>10</index>
+              <type>unsigned value</type>
+              <name>zAngRateValid</name>
+              <description>Compensated z-axis angular rate data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>xAccelValid</name>
+              <description>Compensated x-axis acceleration data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>yAccelValid</name>
+              <description>Compensated y-axis acceleration data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>zAccelValid</name>
+              <description>Compensated z-axis acceleration data validity flag (0: not valid, 1: valid).</description>
+            </type>
+            <type>
+              <index>14:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the HNR epoch.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>xAngRate</name>
+          <type>I4</type>
+          <comment>Compensated x-axis angular rate.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>yAngRate</name>
+          <type>I4</type>
+          <comment>Compensated y-axis angular rate.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>zAngRate</name>
+          <type>I4</type>
+          <comment>Compensated z-axis angular rate.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>xAccel</name>
+          <type>I4</type>
+          <comment>Compensated x-axis acceleration (with
+gravity).</comment>
+          <scale>1e-2</scale>
+          <unit>m/s^2</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>yAccel</name>
+          <type>I4</type>
+          <comment>Compensated y-axis acceleration (with
+gravity).</comment>
+          <scale>1e-2</scale>
+          <unit>m/s^2</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>zAccel</name>
+          <type>I4</type>
+          <comment>Compensated z-axis acceleration (with
+gravity).</comment>
+          <scale>1e-2</scale>
+          <unit>m/s^2</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-HNR-PVT</name>
+    <type>Periodic/Polled</type>
+    <description>High rate output of PVT solution</description>
+    <comment>This message provides the position, velocity and time solution with high output rate. Note that during a leap second there may be more or less than 60 seconds in a minute. See the description of leap seconds for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x28</class>
+      <id>0x00</id>
+      <length>72</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (UTC)</comment>
+          <scale>-</scale>
+          <unit>y</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month, range 1..12 (UTC)</comment>
+          <scale>-</scale>
+          <unit>month</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day of month, range 1..31 (UTC)</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour of day, range 0..23 (UTC)</comment>
+          <scale>-</scale>
+          <unit>h</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>min</name>
+          <type>U1</type>
+          <comment>Minute of hour, range 0..59 (UTC)</comment>
+          <scale>-</scale>
+          <unit>min</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>sec</name>
+          <type>U1</type>
+          <comment>Seconds of minute, range 0..60 (UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>validDate</name>
+              <description>1 = Valid UTC Date (see Integration manual Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>validTime</name>
+              <description>1 = Valid UTC Time of Day (see Integration manual Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>fullyResolved</name>
+              <description>1 = UTC Time of Day has been fully resolved (no seconds uncertainty)</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>nano</name>
+          <type>I4</type>
+          <comment>Fraction of second, range -1e9 .. 1e9 (UTC)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>gpsFix</name>
+          <type>U1</type>
+          <comment>GPSfix Type, range 0..5
+0x00 = No Fix
+0x01 = Dead Reckoning only
+0x02 = 2D-Fix
+0x03 = 3D-Fix
+0x04 = GPS + dead reckoning combined
+0x05 = Time only fix
+0x06..0xff: reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Fix Status Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>GPSfixOK</name>
+              <description>&gt;1 = Fix within limits (e.g. DOP &amp; accuracy)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>DiffSoln</name>
+              <description>1 = DGPS used</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>WKNSET</name>
+              <description>1 = Valid GPS week number</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>TOWSET</name>
+              <description>1 = Valid GPS time of week (iTOW &amp; fTOW)</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>headVehValid</name>
+              <description>1= Heading of vehicle is valid</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>height</name>
+          <type>I4</type>
+          <comment>Height above Ellipsoid</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>hMSL</name>
+          <type>I4</type>
+          <comment>Height above mean sea level</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>gSpeed</name>
+          <type>I4</type>
+          <comment>Ground Speed (2-D)</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>speed</name>
+          <type>I4</type>
+          <comment>Speed (3-D)</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>headMot</name>
+          <type>I4</type>
+          <comment>Heading of motion (2-D)</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>headVeh</name>
+          <type>I4</type>
+          <comment>Heading of vehicle (2-D)</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>hAcc</name>
+          <type>U4</type>
+          <comment>Horizontal accuracy</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>vAcc</name>
+          <type>U4</type>
+          <comment>Vertical accuracy</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>sAcc</name>
+          <type>U4</type>
+          <comment>Speed accuracy</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>headAcc</name>
+          <type>U4</type>
+          <comment>Heading accuracy</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>68</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-INF-DEBUG</name>
+    <type>Output</type>
+    <description>ASCII output with debug contents</description>
+    <comment>This message has a variable length payload, representing an ASCII string.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x04</class>
+      <id>0x04</id>
+      <length>0 + 1*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*1</offset>
+            <name>str</name>
+            <type>CH</type>
+            <comment>ASCII Character</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-INF-ERROR</name>
+    <type>Output</type>
+    <description>ASCII output with error contents</description>
+    <comment>This message has a variable length payload, representing an ASCII string.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x04</class>
+      <id>0x00</id>
+      <length>0 + 1*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*1</offset>
+            <name>str</name>
+            <type>CH</type>
+            <comment>ASCII Character</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-INF-NOTICE</name>
+    <type>Output</type>
+    <description>ASCII output with informational contents</description>
+    <comment>This message has a variable length payload, representing an ASCII string.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x04</class>
+      <id>0x02</id>
+      <length>0 + 1*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*1</offset>
+            <name>str</name>
+            <type>CH</type>
+            <comment>ASCII Character</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-INF-TEST</name>
+    <type>Output</type>
+    <description>ASCII output with test contents</description>
+    <comment>This message has a variable length payload, representing an ASCII string.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x04</class>
+      <id>0x03</id>
+      <length>0 + 1*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*1</offset>
+            <name>str</name>
+            <type>CH</type>
+            <comment>ASCII Character</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-INF-WARNING</name>
+    <type>Output</type>
+    <description>ASCII output with warning contents</description>
+    <comment>This message has a variable length payload, representing an ASCII string.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x04</class>
+      <id>0x01</id>
+      <length>0 + 1*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*1</offset>
+            <name>str</name>
+            <type>CH</type>
+            <comment>ASCII Character</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-BATCH</name>
+    <type>Polled</type>
+    <description>Batched data</description>
+    <comment>This message combines position, velocity and time solution, including accuracy figures. The output of this message can be requested via UBX-LOG-RETRIEVEBATCH. The content of this message is influenced by UBX-CFG-BATCH. Depending on the flags extraPvt and extraOdo some of the fields in this message may not be valid. This validity information is also indicated in this message via flags of the same name. See Data Batching for more information. Note that during a leap second there may be more or less than 60 seconds in a minute. See the description of leap seconds for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x11</id>
+      <length>100</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>contentValid</name>
+          <type>X1</type>
+          <comment>Content validity flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>extraPvt</name>
+              <description>Store extra PVT information
+The fields iTOW, tAcc, numSV, hMSL, vAcc, velN, velE, velD, sAcc, headAcc and pDOP are only valid if
+this flag is set.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>extraOdo</name>
+              <description>Store odometer data
+The fields distance, totalDistance and distanceStd are only valid if this flag is set.
+Note: the odometer feature itself must also be enabled.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>msgCnt</name>
+          <type>U2</type>
+          <comment>Message counter; increments for each
+sent UBX-LOG-BATCH message.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (UTC)</comment>
+          <scale>-</scale>
+          <unit>y</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month, range 1..12 (UTC)</comment>
+          <scale>-</scale>
+          <unit>month</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day of month, range 1..31 (UTC)</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour of day, range 0..23 (UTC)</comment>
+          <scale>-</scale>
+          <unit>h</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>min</name>
+          <type>U1</type>
+          <comment>Minute of hour, range 0..59 (UTC)</comment>
+          <scale>-</scale>
+          <unit>min</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>sec</name>
+          <type>U1</type>
+          <comment>Seconds of minute, range 0..60 (UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>validDate</name>
+              <description>1 = valid UTC Date
+(see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>validTime</name>
+              <description>1 = valid UTC Time of Day
+(see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time accuracy estimate (UTC)
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>fracSec</name>
+          <type>I4</type>
+          <comment>Fraction of second, range -1e9 .. 1e9 (UTC)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>fixType</name>
+          <type>U1</type>
+          <comment>GNSSfix Type:
+0: no fix
+2: 2D-fix
+3: 3D-fix</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Fix status flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gnssFixOK</name>
+              <description>1 = valid fix (i.e within DOP &amp; accuracy masks)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>diffSoln</name>
+              <description>1 = differential corrections were applied</description>
+            </type>
+            <type>
+              <index>2:4</index>
+              <type>unsigned value</type>
+              <name>psmState</name>
+              <description>Power save mode state
+(see Power Management)
+0: PSM is not active
+1: Enabled (an intermediate state before Acquisition state)
+2: Acquisition
+3: Tracking
+4: Power optimized tracking
+5: Inactive</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>flags2</name>
+          <type>X1</type>
+          <comment>Additional flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Number of satellites used in Nav Solution
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>height</name>
+          <type>I4</type>
+          <comment>Height above ellipsoid</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>hMSL</name>
+          <type>I4</type>
+          <comment>Height above mean sea level
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>hAcc</name>
+          <type>U4</type>
+          <comment>Horizontal accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>vAcc</name>
+          <type>U4</type>
+          <comment>Vertical accuracy estimate
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>velN</name>
+          <type>I4</type>
+          <comment>NED north velocity
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>velE</name>
+          <type>I4</type>
+          <comment>NED east velocity
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>velD</name>
+          <type>I4</type>
+          <comment>NED down velocity
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>gSpeed</name>
+          <type>I4</type>
+          <comment>Ground Speed (2-D)</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>68</offset>
+          <name>headMot</name>
+          <type>I4</type>
+          <comment>Heading of motion (2-D)</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>72</offset>
+          <name>sAcc</name>
+          <type>U4</type>
+          <comment>Speed accuracy estimate
+Only valid if extraPvt is set.</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>76</offset>
+          <name>headAcc</name>
+          <type>U4</type>
+          <comment>Heading accuracy estimate
+Only valid if extraPvt is set.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>80</offset>
+          <name>pDOP</name>
+          <type>U2</type>
+          <comment>Position DOP
+Only valid if extraPvt is set.</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>82</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>84</offset>
+          <name>distance</name>
+          <type>U4</type>
+          <comment>Ground distance since last reset
+Only valid if extraOdo is set.</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>88</offset>
+          <name>totalDistance</name>
+          <type>U4</type>
+          <comment>Total cumulative ground distance
+Only valid if extraOdo is set.</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>92</offset>
+          <name>distanceStd</name>
+          <type>U4</type>
+          <comment>Ground distance accuracy (1-sigma)
+Only valid if extraOdo is set.</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>96</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-CREATE</name>
+    <type>Command</type>
+    <description>Create log file</description>
+    <comment>This message is used to create an initial logging file and activate the logging subsystem. UBX-ACK-ACK or UBX-ACK-NAK are returned to indicate success or failure. This message does not handle activation of recording or filtering of log entries (see UBX-CFG-LOGFILTER).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x07</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>logCfg</name>
+          <type>X1</type>
+          <comment>Config flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>circular</name>
+              <description>Log is circular (new entries overwrite old ones in a full log) if this bit set</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>logSize</name>
+          <type>U1</type>
+          <comment>Indicates the size of the log:
+0 (maximum safe size): Ensures that
+logging will not be interrupted and enough
+space will be left available for all other
+uses of the filestore
+1 (minimum size):
+2 (user-defined): See 'userDefinedSize'
+below</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>userDefinedSize</name>
+          <type>U4</type>
+          <comment>Sets the maximum amount of space in the
+filestore that can be used by the logging
+task.
+This field is only applicable if logSize is set
+to user-defined.</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-ERASE</name>
+    <type>Command</type>
+    <description>Erase logged data</description>
+    <comment>This message deactivates the logging system and erases all logged data. UBX-ACK-ACK or UBX-ACK-NAK are returned to indicate success or failure.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x03</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-FINDTIME</name>
+    <type>Input</type>
+    <description>Find index of a log entry based on a given time</description>
+    <comment>This message can be used for a time-based search of a log. It can find the index of the first log entry with time equal to the given time, otherwise the index of the most recent entry with time less than the given time. This index can then be used with the UBX-LOG-RETRIEVE message to provide time-based retrieval of log entries. Searching a log is effective for a given time later than the base date (January 1st, 2004). Searching a log for a given time earlier than the base date will result in an 'entry not found' response. (Searching a log for a given time earlier than the base date will result in a UBX-ACK-NAK message in protocol versions less than 18). Searching a log for a given time greater than the last recorded entry's time will return the index of the last recorded entry. (If the logging has stopped due to lack of file space, such a search will result in a UBX-ACK-NAK message in protocol versions less than 18).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x0E</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type, 0 for request</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (1-65635) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month (1-12) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day (1-31) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour (0-23) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>minute</name>
+          <type>U1</type>
+          <comment>Minute (0-59) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>second</name>
+          <type>U1</type>
+          <comment>Second (0-60) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-FINDTIME</name>
+    <type>Output</type>
+    <description>Response to FINDTIME request</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x0E</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type, 1 for response</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>entryNumber</name>
+          <type>U4</type>
+          <comment>Index of the first log entry with time =
+given time, otherwise index of the most
+recent entry with time &lt; given time. If
+0xFFFFFFFF, no log entry found with time
+&lt;= given time. The indexing of log entries
+is zero-based.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-INFO</name>
+    <type>Poll Request</type>
+    <description>Poll for log information</description>
+    <comment>Upon sending of this message, the receiver returns UBX-LOG-INFO as defined below.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x08</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-INFO</name>
+    <type>Output</type>
+    <description>Log information</description>
+    <comment>This message is used to report information about the logging subsystem. Note:  The reported maximum log size will be smaller than that originally specified in  LOG-CREATE due to logging and filestore implementation overheads.  Log entries are compressed in a variable length fashion, so it may be difficult to  predict log space usage with any precision.  There may be times when the receiver does not have an accurate time (e.g. if  the week number is not yet known), in which case some entries will not have a  timestamp. This may result in the oldest/newest entry time values not taking  account of these entries.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x08</id>
+      <length>48</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>filestoreCapacity</name>
+          <type>U4</type>
+          <comment>The capacity of the filestore</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved2</name>
+          <type>U1[8]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>currentMaxLogSize</name>
+          <type>U4</type>
+          <comment>The maximum size the current log is
+allowed to grow to</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>currentLogSize</name>
+          <type>U4</type>
+          <comment>Approximate amount of space in log
+currently occupied</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>entryCount</name>
+          <type>U4</type>
+          <comment>Number of entries in the log.
+Note: for circular logs this value will
+decrease when a group of entries is
+deleted to make space for new ones.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>oldestYear</name>
+          <type>U2</type>
+          <comment>Oldest entry UTC year (1-65635) or zero if
+there are no entries with known time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>oldestMonth</name>
+          <type>U1</type>
+          <comment>Oldest month (1-12)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>31</offset>
+          <name>oldestDay</name>
+          <type>U1</type>
+          <comment>Oldest day (1-31)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>oldestHour</name>
+          <type>U1</type>
+          <comment>Oldest hour (0-23)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>33</offset>
+          <name>oldestMinute</name>
+          <type>U1</type>
+          <comment>Oldest minute (0-59)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>34</offset>
+          <name>oldestSecond</name>
+          <type>U1</type>
+          <comment>Oldest second (0-60)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>35</offset>
+          <name>reserved3</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>newestYear</name>
+          <type>U2</type>
+          <comment>Newest year (1-65635) or zero if there are
+no entries with known time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>38</offset>
+          <name>newestMonth</name>
+          <type>U1</type>
+          <comment>Newest month (1-12)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>39</offset>
+          <name>newestDay</name>
+          <type>U1</type>
+          <comment>Newest day (1-31)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>newestHour</name>
+          <type>U1</type>
+          <comment>Newest hour (0-23)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>41</offset>
+          <name>newestMinute</name>
+          <type>U1</type>
+          <comment>Newest minute (0-59)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>42</offset>
+          <name>newestSecond</name>
+          <type>U1</type>
+          <comment>Newest second (0-60)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>43</offset>
+          <name>reserved4</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>status</name>
+          <type>X1</type>
+          <comment>Log status flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:2</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>recording</name>
+              <description>Log entry recording is currently turned on</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>inactive</name>
+              <description>Logging system not active - no log present</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>circular</name>
+              <description>The current log is circular</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>45</offset>
+          <name>reserved5</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-RETRIEVEBATCH</name>
+    <type>Command</type>
+    <description>Request batch data</description>
+    <comment>This message is used to request batched data. Batch entries are returned in chronological order, using one UBX-LOG-BATCH per navigation epoch. The speed of transfer can be maximized by using a high data rate. See Data Batching for more information.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x10</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>sendMonFirst</name>
+              <description>Send UBX-MON-BATCH message before sending the UBX-LOG-BATCH message(s).</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-RETRIEVEPOSEXTRA</name>
+    <type>Output</type>
+    <description>Odometer log entry</description>
+    <comment>This message is used to report an odometer log entry</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x0f</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>entryIndex</name>
+          <type>U4</type>
+          <comment>The index of this log entry</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (1-65635) of UTC time. Will be zero if
+time not known</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month (1-12) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day (1-31) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour (0-23) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>minute</name>
+          <type>U1</type>
+          <comment>Minute (0-59) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>second</name>
+          <type>U1</type>
+          <comment>Second (0-60) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>distance</name>
+          <type>U4</type>
+          <comment>Odometer distance traveled since the last
+time the odometer was reset by a UBX-
+NAV-RESETODO</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>reserved3</name>
+          <type>U1[12]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-RETRIEVEPOS</name>
+    <type>Output</type>
+    <description>Position fix log entry</description>
+    <comment>This message is used to report a position fix log entry</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x0b</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>entryIndex</name>
+          <type>U4</type>
+          <comment>The index of this log entry</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>hMSL</name>
+          <type>I4</type>
+          <comment>Height above mean sea level</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>hAcc</name>
+          <type>U4</type>
+          <comment>Horizontal accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>gSpeed</name>
+          <type>U4</type>
+          <comment>Ground speed (2-D)</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>heading</name>
+          <type>U4</type>
+          <comment>Heading</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>29</offset>
+          <name>fixType</name>
+          <type>U1</type>
+          <comment>Fix type:
+0x01: Dead Reckoning only
+0x02: 2D-Fix
+0x03: 3D-Fix
+0x04: GNSS + Dead Reckoning combined</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (1-65635) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month (1-12) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>33</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day (1-31) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>34</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour (0-23) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>35</offset>
+          <name>minute</name>
+          <type>U1</type>
+          <comment>Minute (0-59) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>second</name>
+          <type>U1</type>
+          <comment>Second (0-60) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>37</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>38</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Number of satellites used in the position
+fix</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>39</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-RETRIEVESTRING</name>
+    <type>Output</type>
+    <description>Byte string log entry</description>
+    <comment>This message is used to report a byte string log entry</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x0d</id>
+      <length>16 + 1*byteCount</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>entryIndex</name>
+          <type>U4</type>
+          <comment>The index of this log entry</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (1-65635) of UTC time. Will be zero if
+time not known</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month (1-12) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day (1-31) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour (0-23) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>minute</name>
+          <type>U1</type>
+          <comment>Minute (0-59) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>second</name>
+          <type>U1</type>
+          <comment>Second (0-60) of UTC time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>byteCount</name>
+          <type>U2</type>
+          <comment>Size of string in bytes</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="byteCount" type="repeated">
+          <block>
+            <offset>16 + 1*N</offset>
+            <name>bytes</name>
+            <type>U1</type>
+            <comment>The bytes of the string</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-RETRIEVE</name>
+    <type>Command</type>
+    <description>Request log data</description>
+    <comment>This message is used to request logged data (log recording must first be disabled, see UBX-CFG-LOGFILTER). Log entries are returned in chronological order, using the messages UBX-LOG- RETRIEVEPOS and UBX-LOG-RETRIEVESTRING. If the odometer was enabled at the time a position was logged, then message UBX-LOG-RETRIEVEPOSEXTRA will also be used. The maximum number of entries that can be returned in response to a single UBX-LOG-RETRIEVE message is 256. If more entries than this are required the message will need to be sent multiple times with different startNumbers. The retrieve will be stopped if any UBX-LOG message is received. The speed of transfer can be maximized by using a high data rate and temporarily stopping the GPS processing (see UBX-CFG-RST).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x09</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>startNumber</name>
+          <type>U4</type>
+          <comment>Index of first log entry to be transferred. If
+it is larger than the index of the last
+available log entry, then the first log entry
+to be transferred is the last available log
+entry. The indexing of log entries is zero-
+based.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>entryCount</name>
+          <type>U4</type>
+          <comment>Number of log entries to transfer in total
+including the first entry to be transferred.
+If it is larger than the log entries available
+starting from the first entry to be
+transferred, then only the available log
+entries are transferred followed by a UBX-
+ACK-NAK. The maximum is 256.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-LOG-STRING</name>
+    <type>Command</type>
+    <description>Store arbitrary string in on-board flash</description>
+    <comment>This message can be used to store an arbitrary byte string in the on-board flash memory. The maximum length that can be stored is 256 bytes.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x21</class>
+      <id>0x04</id>
+      <length>0 + 1*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*1</offset>
+            <name>bytes</name>
+            <type>U1</type>
+            <comment>The string of bytes to be logged
+(maximum 256)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-ACK-DATA0</name>
+    <type>Output</type>
+    <description>Multiple GNSS acknowledge message</description>
+    <comment>This message is sent by a u-blox receiver to acknowledge the receipt of an assistance message. Acknowledgments are enabled by setting the ackAiding parameter in the UBX- CFG-NAVX5 message. See the description of flow control for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x60</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Type of acknowledgment:
+0: The message was not used by the
+receiver (see infoCode field for an
+indication of why)
+1: The message was accepted for use by
+the receiver (the infoCode field will be 0)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>infoCode</name>
+          <type>U1</type>
+          <comment>Provides greater information on what the
+receiver chose to do with the message
+contents:
+0: The receiver accepted the data
+1: The receiver does not know the time so
+it cannot use the data (To resolve this a
+UBX-MGA-INI-TIME_UTC message should
+be supplied first)
+2: The message version is not supported
+by the receiver
+3: The message size does not match the
+message version
+4: The message data could not be stored
+to the database
+5: The receiver is not ready to use the
+message data
+6: The message type is unknown</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>msgId</name>
+          <type>U1</type>
+          <comment>UBX message ID of the acknowledged
+message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>msgPayloadStart</name>
+          <type>U1[4]</type>
+          <comment>The first 4 bytes of the acknowledged
+message's payload</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-ANO</name>
+    <type>Input</type>
+    <description>Multiple GNSS AssistNow Offline assistance</description>
+    <comment>This message is created by the AssistNow Offline service to deliver AssistNow Offline assistance to the receiver. See the description of AssistNow Offline for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x20</id>
+      <length>76</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x00 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>gnssId</name>
+          <type>U1</type>
+          <comment>GNSS identifier (see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>year</name>
+          <type>U1</type>
+          <comment>years since the year 2000</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>month (1..12)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>day (1..31)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>data</name>
+          <type>U1[64]</type>
+          <comment>assistance data</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>72</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-BDS-EPH</name>
+    <type>Input</type>
+    <description>BeiDou ephemeris assistance</description>
+    <comment>This message allows the delivery of BeiDou ephemeris assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x03</id>
+      <length>88</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>BeiDou satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>SatH1</name>
+          <type>U1</type>
+          <comment>Autonomous satellite Health flag</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>IODC</name>
+          <type>U1</type>
+          <comment>Issue of Data, Clock</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>a2</name>
+          <type>I2</type>
+          <comment>Time polynomial coefficient 2</comment>
+          <scale>2^-66</scale>
+          <unit>s/s^2</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>a1</name>
+          <type>I4</type>
+          <comment>Time polynomial coefficient 1</comment>
+          <scale>2^-50</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>a0</name>
+          <type>I4</type>
+          <comment>Time polynomial coefficient 0</comment>
+          <scale>2^-33</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>toc</name>
+          <type>U4</type>
+          <comment>Clock data reference time</comment>
+          <scale>2^3</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>TGD1</name>
+          <type>I2</type>
+          <comment>Equipment Group Delay Differential</comment>
+          <scale>0.1</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>URAI</name>
+          <type>U1</type>
+          <comment>User Range Accuracy Index</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>IODE</name>
+          <type>U1</type>
+          <comment>Issue of Data, Ephemeris</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>toe</name>
+          <type>U4</type>
+          <comment>Ephemeris reference time</comment>
+          <scale>2^3</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Square root of semi-major axis</comment>
+          <scale>2^-19</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>e</name>
+          <type>U4</type>
+          <comment>Eccentricity</comment>
+          <scale>2^-33</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Argument of perigee</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>Deltan</name>
+          <type>I2</type>
+          <comment>Mean motion difference from computed
+value</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>42</offset>
+          <name>IDOT</name>
+          <type>I2</type>
+          <comment>Rate of inclination angle</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>M0</name>
+          <type>I4</type>
+          <comment>Mean anomaly at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>Omega0</name>
+          <type>I4</type>
+          <comment>Longitude of ascending node of orbital of
+plane computed according to reference
+time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>OmegaDot</name>
+          <type>I4</type>
+          <comment>Rate of right ascension</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>i0</name>
+          <type>I4</type>
+          <comment>Inclination angle at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>Cuc</name>
+          <type>I4</type>
+          <comment>Amplitude of cosine harmonic correction
+term to the argument of latitude</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>Cus</name>
+          <type>I4</type>
+          <comment>Amplitude of sine harmonic correction
+term to the argument of latitude</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>68</offset>
+          <name>Crc</name>
+          <type>I4</type>
+          <comment>Amplitude of cosine harmonic correction
+term to the orbit radius</comment>
+          <scale>2^-6</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>72</offset>
+          <name>Crs</name>
+          <type>I4</type>
+          <comment>Amplitude of sine harmonic correction
+term to the orbit radius</comment>
+          <scale>2^-6</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>76</offset>
+          <name>Cic</name>
+          <type>I4</type>
+          <comment>Amplitude of cosine harmonic correction
+term to the angle of inclination</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>80</offset>
+          <name>Cis</name>
+          <type>I4</type>
+          <comment>Amplitude of sine harmonic correction
+term to the angle of inclination</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>84</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-BDS-ALM</name>
+    <type>Input</type>
+    <description>BeiDou almanac assistance</description>
+    <comment>This message allows the delivery of BeiDou almanac assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x03</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>BeiDou satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>Wna</name>
+          <type>U1</type>
+          <comment>Almanac Week Number</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>toa</name>
+          <type>U1</type>
+          <comment>Almanac reference time</comment>
+          <scale>2^12</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>deltaI</name>
+          <type>I2</type>
+          <comment>Almanac correction of orbit reference
+inclination at reference time</comment>
+          <scale>2^-19</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Almanac square root of semi-major axis</comment>
+          <scale>2^-11</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>e</name>
+          <type>U4</type>
+          <comment>Almanac eccentricity</comment>
+          <scale>2^-21</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Almanac argument of perigee</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>M0</name>
+          <type>I4</type>
+          <comment>Almanac mean anomaly at reference time</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>Omega0</name>
+          <type>I4</type>
+          <comment>Almanac longitude of ascending node of
+orbit plane at computed according to
+reference time</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>omegaDot</name>
+          <type>I4</type>
+          <comment>Almanac rate of right ascension</comment>
+          <scale>2^-38</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>a0</name>
+          <type>I2</type>
+          <comment>Almanac satellite clock bias</comment>
+          <scale>2^-20</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>34</offset>
+          <name>a1</name>
+          <type>I2</type>
+          <comment>Almanac satellite clock rate</comment>
+          <scale>2^-38</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-BDS-HEALTH</name>
+    <type>Input</type>
+    <description>BeiDou health assistance</description>
+    <comment>This message allows the delivery of BeiDou health assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x03</id>
+      <length>68</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x04 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>healthCode</name>
+          <type>U2[30]</type>
+          <comment>Each two-byte value represents a BeiDou
+SV (1-30). The 9 LSBs of each byte contain
+the 9 bit health code from subframe 5
+pages 7,8 of the D1 message, and from
+subframe 5 pages 35,36 of the D1
+message.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-BDS-UTC</name>
+    <type>Input</type>
+    <description>BeiDou UTC assistance</description>
+    <comment>This message allows the delivery of BeiDou UTC assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x03</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x05 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>a0UTC</name>
+          <type>I4</type>
+          <comment>BDT clock bias relative to UTC</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>a1UTC</name>
+          <type>I4</type>
+          <comment>BDT clock rate relative to UTC</comment>
+          <scale>2^-50</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>dtLS</name>
+          <type>I1</type>
+          <comment>Delta time due to leap seconds before the
+new leap second effective</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved2</name>
+          <type>U1[1]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>wnRec</name>
+          <type>U1</type>
+          <comment>BeiDou week number of reception of this
+UTC parameter set (8-bit truncated)</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>wnLSF</name>
+          <type>U1</type>
+          <comment>Week number of the new leap second</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>dN</name>
+          <type>U1</type>
+          <comment>Day number of the new leap second</comment>
+          <scale>-</scale>
+          <unit>day</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>dtLSF</name>
+          <type>I1</type>
+          <comment>Delta time due to leap seconds after the
+new leap second effective</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-BDS-IONO</name>
+    <type>Input</type>
+    <description>BeiDou ionosphere assistance</description>
+    <comment>This message allows the delivery of BeiDou ionospheric assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x03</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x06 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>alpha0</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha0</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>alpha1</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha1</comment>
+          <scale>2^-27</scale>
+          <unit>s/pi</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>alpha2</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha2</comment>
+          <scale>2^-24</scale>
+          <unit>s/pi^2</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>alpha3</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha3</comment>
+          <scale>2^-24</scale>
+          <unit>s/pi^3</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>beta0</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta0</comment>
+          <scale>2^11</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>beta1</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta1</comment>
+          <scale>2^14</scale>
+          <unit>s/pi</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>beta2</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta2</comment>
+          <scale>2^16</scale>
+          <unit>s/pi^2</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>beta3</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta3</comment>
+          <scale>2^16</scale>
+          <unit>s/pi^3</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-DBD</name>
+    <type>Poll Request</type>
+    <description>Poll the navigation database</description>
+    <comment>Poll the whole navigation data base. The receiver will send all available data from its internal database. The receiver will indicate the finish of the transmission with a UBX-MGA-ACK. The msgPayloadStart field of the UBX-MGA-ACK message will contain a U4 representing the number of UBX-MGA-DBD-DATA* messages sent.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x80</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-DBD</name>
+    <type>Input/Output</type>
+    <description>Navigation database dump entry</description>
+    <comment>UBX-MGA-DBD messages are only intended to be sent back to the same receiver that generated them. Navigation database entry. The data fields are firmware-specific. Transmission of this type of message will be acknowledged by UBX-MGA-ACK messages, if acknowledgment has been enabled. See the description of flow control for details. The maximum payload size for firmware 2.01 onwards is 164 bytes (which makes the maximum message size 172 bytes).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x80</id>
+      <length>12 + 1*N</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>reserved1</name>
+          <type>U1[12]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="N" type="repeated">
+          <block>
+            <offset>12 + 1*N</offset>
+            <name>data</name>
+            <type>U1</type>
+            <comment>firmware-specific data</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-FLASH-DATA</name>
+    <type>Input</type>
+    <description>Transfer MGA-ANO data block to flash</description>
+    <comment>This message is used to transfer a block of MGA-ANO data from host to the receiver. Upon reception of this message, the receiver will write the payload data to its internal non-volatile memory (flash). Also, on reception of the first MGA- FLASH-DATA message, the receiver will erase the flash allocated to storing any existing MGA-ANO data. The payload can be up to 512 bytes. Payloads larger than this would exceed the receiver's internal buffering capabilities. The receiver will ACK/NACK this message using the message alternatives given below. The host shall wait for an acknowledge message before sending the next data block. See Flash-based AssistNow Offline for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x21</id>
+      <length>6 + 1*size</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>sequence</name>
+          <type>U2</type>
+          <comment>Message sequence number, starting at 0
+and increamenting by 1 for each MGA-
+FLASH-DATA message sent.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>size</name>
+          <type>U2</type>
+          <comment>Payload size in bytes.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="size" type="repeated">
+          <block>
+            <offset>6 + 1*N</offset>
+            <name>data</name>
+            <type>U1</type>
+            <comment>Payload data.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-FLASH-STOP</name>
+    <type>Input</type>
+    <description>Finish flashing MGA-ANO data</description>
+    <comment>This message is used to tell the receiver that there are no more MGA-FLASH type 1 messages coming, and that it can do any final internal operations needed to commit the data to flash as a background activity. A UBX-MGA-ACK message will be sent at the end of this process. Note that there may be a delay of several seconds before the UBX-MGA-ACK for this message is sent because of the time taken for this processing. See Flash-based AssistNow Offline for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x21</id>
+      <length>2</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-FLASH-ACK</name>
+    <type>Output</type>
+    <description>Acknowledge last FLASH-DATA or -STOP</description>
+    <comment>This message reports an ACK/NACK to the host for the last MGA-FLASH type 1 or type 2 message message received. See Flash-based AssistNow Offline for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x21</id>
+      <length>6</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x03 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>ack</name>
+          <type>U1</type>
+          <comment>Acknowledgment type. 0 - ACK: Message
+received and written to flash. 1 - NACK:
+Problem with last message, re-
+transmission required (this only happens
+while acknowledging a UBX-MGA_FLASH_
+DATA message). 2 - NACK: problem with
+last message, give up.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>sequence</name>
+          <type>U2</type>
+          <comment>If acknowledging a UBX-MGA-FLASH-
+DATA message this is the Message
+sequence number being ack'ed. If
+acknowledging a UBX-MGA-FLASH-STOP
+message it will be set to 0xffff.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GAL-EPH</name>
+    <type>Input</type>
+    <description>Galileo ephemeris assistance</description>
+    <comment>This message allows the delivery of Galileo ephemeris assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x02</id>
+      <length>76</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Galileo Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iodNav</name>
+          <type>U2</type>
+          <comment>Ephemeris and clock correction Issue of
+Data</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>deltaN</name>
+          <type>I2</type>
+          <comment>Mean motion difference from computed
+value</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>m0</name>
+          <type>I4</type>
+          <comment>Mean anomaly at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>e</name>
+          <type>U4</type>
+          <comment>Eccentricity</comment>
+          <scale>2^-33</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Square root of the semi-major axis</comment>
+          <scale>2^-19</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>omega0</name>
+          <type>I4</type>
+          <comment>Longitude of ascending node of orbital
+plane at weekly epoch</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>i0</name>
+          <type>I4</type>
+          <comment>Inclination angle at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Argument of perigee</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>omegaDot</name>
+          <type>I4</type>
+          <comment>Rate of change of right ascension</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>iDot</name>
+          <type>I2</type>
+          <comment>Rate of change of inclination angle</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>38</offset>
+          <name>cuc</name>
+          <type>I2</type>
+          <comment>Amplitude of the cosine harmonic
+correction term to the argument of
+latitude</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>cus</name>
+          <type>I2</type>
+          <comment>Amplitude of the sine harmonic correction
+term to the argument of latitude</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>42</offset>
+          <name>crc</name>
+          <type>I2</type>
+          <comment>Amplitude of the cosine harmonic
+correction term to the orbit radius</comment>
+          <scale>2^-5</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>crs</name>
+          <type>I2</type>
+          <comment>Amplitude of the sine harmonic correction
+term to the orbit radius</comment>
+          <scale>2^-5</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>46</offset>
+          <name>cic</name>
+          <type>I2</type>
+          <comment>Amplitude of the cosine harmonic
+correction term to the angle of inclination</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>cis</name>
+          <type>I2</type>
+          <comment>Amplitude of the sine harmonic correction
+term to the angle of inclination</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>50</offset>
+          <name>toe</name>
+          <type>U2</type>
+          <comment>Ephemeris reference time</comment>
+          <scale>60</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>af0</name>
+          <type>I4</type>
+          <comment>SV clock bias correction coefficient</comment>
+          <scale>2^-34</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>af1</name>
+          <type>I4</type>
+          <comment>SV clock drift correction coefficient</comment>
+          <scale>2^-46</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>af2</name>
+          <type>I1</type>
+          <comment>SV clock drift rate correction coefficient</comment>
+          <scale>2^-59</scale>
+          <unit>s/ssquared</unit>
+        </block>
+        <block>
+          <offset>61</offset>
+          <name>sisaIndexE1E5b</name>
+          <type>U1</type>
+          <comment>Signal-In-Space Accuracy index for dual
+frequency E1-E5b</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>62</offset>
+          <name>toc</name>
+          <type>U2</type>
+          <comment>Clock correction data reference Time of
+Week</comment>
+          <scale>60</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>bgdE1E5b</name>
+          <type>I2</type>
+          <comment>E1-E5b Broadcast Group Delay</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>66</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>68</offset>
+          <name>healthE1B</name>
+          <type>U1</type>
+          <comment>E1-B Signal Health Status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>69</offset>
+          <name>dataValidityE1B</name>
+          <type>U1</type>
+          <comment>E1-B Data Validity Status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>70</offset>
+          <name>healthE5b</name>
+          <type>U1</type>
+          <comment>E5b Signal Health Status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>71</offset>
+          <name>dataValidityE5b</name>
+          <type>U1</type>
+          <comment>E5b Data Validity Status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>72</offset>
+          <name>reserved3</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GAL-ALM</name>
+    <type>Input</type>
+    <description>Galileo almanac assistance</description>
+    <comment>This message allows the delivery of Galileo almanac assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x02</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Galileo Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ioda</name>
+          <type>U1</type>
+          <comment>Almanac Issue of Data</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>almWNa</name>
+          <type>U1</type>
+          <comment>Almanac reference week number</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>toa</name>
+          <type>U2</type>
+          <comment>Almanac reference time</comment>
+          <scale>600</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>deltaSqrtA</name>
+          <type>I2</type>
+          <comment>Difference with respect to the square root
+of the nominal semi-major axis (29 600
+km)</comment>
+          <scale>2^-9</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>e</name>
+          <type>U2</type>
+          <comment>Eccentricity</comment>
+          <scale>2^-16</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>deltaI</name>
+          <type>I2</type>
+          <comment>Inclination at reference time relative to i0
+= 56 degree</comment>
+          <scale>2^-14</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>omega0</name>
+          <type>I2</type>
+          <comment>Longitude of ascending node of orbital
+plane at weekly epoch</comment>
+          <scale>2^-15</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>omegaDot</name>
+          <type>I2</type>
+          <comment>Rate of change of right ascension</comment>
+          <scale>2^-33</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>omega</name>
+          <type>I2</type>
+          <comment>Argument of perigee</comment>
+          <scale>2^-15</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>m0</name>
+          <type>I2</type>
+          <comment>Satellite mean anomaly at reference time</comment>
+          <scale>2^-15</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>af0</name>
+          <type>I2</type>
+          <comment>Satellite clock correction bias 'truncated'</comment>
+          <scale>2^-19</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>af1</name>
+          <type>I2</type>
+          <comment>Satellite clock correction linear 'truncated'</comment>
+          <scale>2^-38</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>healthE1B</name>
+          <type>U1</type>
+          <comment>Satellite E1-B signal health status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>healthE5b</name>
+          <type>U1</type>
+          <comment>Satellite E5b signal health status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GAL-TIMEOFFSET</name>
+    <type>Input</type>
+    <description>Galileo GPS time offset assistance</description>
+    <comment>This message allows the delivery of Galileo time to GPS time offset. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x02</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x03 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>a0G</name>
+          <type>I2</type>
+          <comment>Constant term of the polynomial
+describing the offset</comment>
+          <scale>2^-35</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>a1G</name>
+          <type>I2</type>
+          <comment>Rate of change of the offset</comment>
+          <scale>2^-51</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>t0G</name>
+          <type>U1</type>
+          <comment>Reference time for GGTO data</comment>
+          <scale>3600</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>wn0G</name>
+          <type>U1</type>
+          <comment>Week Number of GGTO reference</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GAL-UTC</name>
+    <type>Input</type>
+    <description>Galileo UTC assistance</description>
+    <comment>This message allows the delivery of Galileo UTC assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x02</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x05 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>a0</name>
+          <type>I4</type>
+          <comment>First parameter of UTC polynomial</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>a1</name>
+          <type>I4</type>
+          <comment>Second parameter of UTC polynomial</comment>
+          <scale>2^-50</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>dtLS</name>
+          <type>I1</type>
+          <comment>Delta time due to current leap seconds</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>tot</name>
+          <type>U1</type>
+          <comment>UTC parameters reference time of week
+(Galileo time)</comment>
+          <scale>3600</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>wnt</name>
+          <type>U1</type>
+          <comment>UTC parameters reference week number
+(the 8-bit WNt field)</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>wnLSF</name>
+          <type>U1</type>
+          <comment>Week number at the end of which the
+future leap second becomes effective (the
+8-bit WNLSF field)</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>dN</name>
+          <type>U1</type>
+          <comment>Day number at the end of which the future
+leap second becomes effective</comment>
+          <scale>-</scale>
+          <unit>days</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>dTLSF</name>
+          <type>I1</type>
+          <comment>Delta time due to future leap seconds</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GLO-EPH</name>
+    <type>Input</type>
+    <description>GLONASS ephemeris assistance</description>
+    <comment>This message allows the delivery of GLONASS ephemeris assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x06</id>
+      <length>48</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>GLONASS Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>FT</name>
+          <type>U1</type>
+          <comment>User range accuracy</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>B</name>
+          <type>U1</type>
+          <comment>Health flag from string 2</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>M</name>
+          <type>U1</type>
+          <comment>Type of GLONASS satellite (1 indicates
+GLONASS-M)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>H</name>
+          <type>I1</type>
+          <comment>Carrier frequency number of navigation RF
+signal, Range=(-7 .. 6), -128 for unknown</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>x</name>
+          <type>I4</type>
+          <comment>X component of the SV position in PZ-90.
+02 coordinate System</comment>
+          <scale>2^-11</scale>
+          <unit>km</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>y</name>
+          <type>I4</type>
+          <comment>Y component of the SV position in PZ-90.
+02 coordinate System</comment>
+          <scale>2^-11</scale>
+          <unit>km</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>z</name>
+          <type>I4</type>
+          <comment>Z component of the SV position in PZ-90.
+02 coordinate System</comment>
+          <scale>2^-11</scale>
+          <unit>km</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>dx</name>
+          <type>I4</type>
+          <comment>X component of the SV velocity in PZ-90.
+02 coordinate System</comment>
+          <scale>2^-20</scale>
+          <unit>km/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>dy</name>
+          <type>I4</type>
+          <comment>Y component of the SV velocity in PZ-90.
+02 coordinate System</comment>
+          <scale>2^-20</scale>
+          <unit>km/s</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>dz</name>
+          <type>I4</type>
+          <comment>Z component of the SV velocity in PZ-90.
+02 coordinate System</comment>
+          <scale>2^-20</scale>
+          <unit>km/s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>ddx</name>
+          <type>I1</type>
+          <comment>X component of the SV acceleration in PZ-
+90.02 coordinate System</comment>
+          <scale>2^-30</scale>
+          <unit>km/s^2</unit>
+        </block>
+        <block>
+          <offset>33</offset>
+          <name>ddy</name>
+          <type>I1</type>
+          <comment>Y component of the SV acceleration in PZ-
+90.02 coordinate System</comment>
+          <scale>2^-30</scale>
+          <unit>km/s^2</unit>
+        </block>
+        <block>
+          <offset>34</offset>
+          <name>ddz</name>
+          <type>I1</type>
+          <comment>Z component of the SV acceleration in PZ-
+90.02 coordinate System</comment>
+          <scale>2^-30</scale>
+          <unit>km/s^2</unit>
+        </block>
+        <block>
+          <offset>35</offset>
+          <name>tb</name>
+          <type>U1</type>
+          <comment>Index of a time interval within current day
+according to UTC(SU)</comment>
+          <scale>15</scale>
+          <unit>minutes</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>gamma</name>
+          <type>I2</type>
+          <comment>Relative carrier frequency deviation</comment>
+          <scale>2^-40</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>38</offset>
+          <name>E</name>
+          <type>U1</type>
+          <comment>Ephemeris data age indicator</comment>
+          <scale>-</scale>
+          <unit>days</unit>
+        </block>
+        <block>
+          <offset>39</offset>
+          <name>deltaTau</name>
+          <type>I1</type>
+          <comment>Time difference between L2 and L1 band</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>tau</name>
+          <type>I4</type>
+          <comment>SV clock bias</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GLO-ALM</name>
+    <type>Input</type>
+    <description>GLONASS almanac assistance</description>
+    <comment>This message allows the delivery of GLONASS almanac assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x06</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>GLONASS Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>N</name>
+          <type>U2</type>
+          <comment>Reference calender day number of
+almanac within the four-year period (from
+string 5)</comment>
+          <scale>-</scale>
+          <unit>days</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>M</name>
+          <type>U1</type>
+          <comment>Type of GLONASS satellite (1 indicates
+GLONASS-M)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>C</name>
+          <type>U1</type>
+          <comment>Unhealthy flag at instant of almanac
+upload (1 indicates operability of satellite)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>tau</name>
+          <type>I2</type>
+          <comment>Coarse time correction to GLONASS time</comment>
+          <scale>2^-18</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>epsilon</name>
+          <type>U2</type>
+          <comment>Eccentricity</comment>
+          <scale>2^-20</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>lambda</name>
+          <type>I4</type>
+          <comment>Longitude of the first (within the N-day)
+ascending node of satellite orbit in PC-90.
+02 coordinate system</comment>
+          <scale>2^-20</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>deltaI</name>
+          <type>I4</type>
+          <comment>Correction to the mean value of inclination</comment>
+          <scale>2^-20</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>tLambda</name>
+          <type>U4</type>
+          <comment>Time of the first ascending node passage</comment>
+          <scale>2^-5</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>deltaT</name>
+          <type>I4</type>
+          <comment>Correction to the mean value of Draconian
+period</comment>
+          <scale>2^-9</scale>
+          <unit>s/orbital-period</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>deltaDT</name>
+          <type>I1</type>
+          <comment>Rate of change of Draconian period</comment>
+          <scale>2^-14</scale>
+          <unit>s/orbital-period^2</unit>
+        </block>
+        <block>
+          <offset>29</offset>
+          <name>H</name>
+          <type>I1</type>
+          <comment>Carrier frequency number of navigation RF
+signal, Range=(-7 .. 6)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>omega</name>
+          <type>I2</type>
+          <comment>Argument of perigee</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GLO-TIMEOFFSET</name>
+    <type>Input</type>
+    <description>GLONASS auxiliary time offset assistance</description>
+    <comment>This message allows the delivery of auxiliary GLONASS assistance (including the GLONASS time offsets to other GNSS systems) to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x06</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x03 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>N</name>
+          <type>U2</type>
+          <comment>Reference calendar day number within the
+four-year period of almanac (from string 5)</comment>
+          <scale>-</scale>
+          <unit>days</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>tauC</name>
+          <type>I4</type>
+          <comment>Time scale correction to UTC(SU) time</comment>
+          <scale>2^-27</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>tauGps</name>
+          <type>I4</type>
+          <comment>Correction to GPS time relative to
+GLONASS time</comment>
+          <scale>2^-31</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>B1</name>
+          <type>I2</type>
+          <comment>Coefficient to determine delta UT1</comment>
+          <scale>2^-10</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>B2</name>
+          <type>I2</type>
+          <comment>Rate of change of delta UT1</comment>
+          <scale>2^-16</scale>
+          <unit>s/msd</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GPS-EPH</name>
+    <type>Input</type>
+    <description>GPS ephemeris assistance</description>
+    <comment>This message allows the delivery of GPS ephemeris assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x00</id>
+      <length>68</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>GPS Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>fitInterval</name>
+          <type>U1</type>
+          <comment>Fit interval flag</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>uraIndex</name>
+          <type>U1</type>
+          <comment>URA index</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>svHealth</name>
+          <type>U1</type>
+          <comment>SV health</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>tgd</name>
+          <type>I1</type>
+          <comment>Group delay differential</comment>
+          <scale>2^-31</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>iodc</name>
+          <type>U2</type>
+          <comment>IODC</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>toc</name>
+          <type>U2</type>
+          <comment>Clock data reference time</comment>
+          <scale>2^4</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>af2</name>
+          <type>I1</type>
+          <comment>Time polynomial coefficient 2</comment>
+          <scale>2^-55</scale>
+          <unit>s/ssquared</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>af1</name>
+          <type>I2</type>
+          <comment>Time polynomial coefficient 1</comment>
+          <scale>2^-43</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>af0</name>
+          <type>I4</type>
+          <comment>Time polynomial coefficient 0</comment>
+          <scale>2^-31</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>crs</name>
+          <type>I2</type>
+          <comment>Crs</comment>
+          <scale>2^-5</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>deltaN</name>
+          <type>I2</type>
+          <comment>Mean motion difference from computed
+value</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>m0</name>
+          <type>I4</type>
+          <comment>Mean anomaly at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>cuc</name>
+          <type>I2</type>
+          <comment>Amplitude of cosine harmonic correction
+term to argument of latitude</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>cus</name>
+          <type>I2</type>
+          <comment>Amplitude of sine harmonic correction
+term to argument of latitude</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>e</name>
+          <type>U4</type>
+          <comment>Eccentricity</comment>
+          <scale>2^-33</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Square root of the semi-major axis</comment>
+          <scale>2^-19</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>toe</name>
+          <type>U2</type>
+          <comment>Reference time of ephemeris</comment>
+          <scale>2^4</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>42</offset>
+          <name>cic</name>
+          <type>I2</type>
+          <comment>Amplitude of cos harmonic correction
+term to angle of inclination</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>omega0</name>
+          <type>I4</type>
+          <comment>Longitude of ascending node of orbit
+plane at weekly epoch</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>cis</name>
+          <type>I2</type>
+          <comment>Amplitude of sine harmonic correction
+term to angle of inclination</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>50</offset>
+          <name>crc</name>
+          <type>I2</type>
+          <comment>Amplitude of cosine harmonic correction
+term to orbit radius</comment>
+          <scale>2^-5</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>i0</name>
+          <type>I4</type>
+          <comment>Inclination angle at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Argument of perigee</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>omegaDot</name>
+          <type>I4</type>
+          <comment>Rate of right ascension</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>idot</name>
+          <type>I2</type>
+          <comment>Rate of inclination angle</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>66</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GPS-ALM</name>
+    <type>Input</type>
+    <description>GPS almanac assistance</description>
+    <comment>This message allows the delivery of GPS almanac assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x00</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>GPS Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>svHealth</name>
+          <type>U1</type>
+          <comment>SV health information</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>e</name>
+          <type>U2</type>
+          <comment>Eccentricity</comment>
+          <scale>2^-21</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>almWNa</name>
+          <type>U1</type>
+          <comment>Reference week number of almanac (the
+8-bit WNa field)</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>toa</name>
+          <type>U1</type>
+          <comment>Reference time of almanac</comment>
+          <scale>2^12</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>deltaI</name>
+          <type>I2</type>
+          <comment>Delta inclination angle at reference time</comment>
+          <scale>2^-19</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>omegaDot</name>
+          <type>I2</type>
+          <comment>Rate of right ascension</comment>
+          <scale>2^-38</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Square root of the semi-major axis</comment>
+          <scale>2^-11</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>omega0</name>
+          <type>I4</type>
+          <comment>Longitude of ascending node of orbit
+plane</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Argument of perigee</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>m0</name>
+          <type>I4</type>
+          <comment>Mean anomaly at reference time</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>af0</name>
+          <type>I2</type>
+          <comment>Time polynomial coefficient 0 (8 MSBs)</comment>
+          <scale>2^-20</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>af1</name>
+          <type>I2</type>
+          <comment>Time polynomial coefficient 1</comment>
+          <scale>2^-38</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GPS-HEALTH</name>
+    <type>Input</type>
+    <description>GPS health assistance</description>
+    <comment>This message allows the delivery of GPS health assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x00</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x04 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>healthCode</name>
+          <type>U1[32]</type>
+          <comment>Each byte represents a GPS SV (1-32). The
+6 LSBs of each byte contains the 6 bit
+health code from subframes 4/5 page 25.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GPS-UTC</name>
+    <type>Input</type>
+    <description>GPS UTC assistance</description>
+    <comment>This message allows the delivery of GPS UTC assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x00</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x05 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>utcA0</name>
+          <type>I4</type>
+          <comment>First parameter of UTC polynomial</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>utcA1</name>
+          <type>I4</type>
+          <comment>Second parameter of UTC polynomial</comment>
+          <scale>2^-50</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>utcDtLS</name>
+          <type>I1</type>
+          <comment>Delta time due to current leap seconds</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>utcTot</name>
+          <type>U1</type>
+          <comment>UTC parameters reference time of week
+(GPS time)</comment>
+          <scale>2^12</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>utcWNt</name>
+          <type>U1</type>
+          <comment>UTC parameters reference week number
+(the 8-bit WNt field)</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>utcWNlsf</name>
+          <type>U1</type>
+          <comment>Week number at the end of which the
+future leap second becomes effective (the
+8-bit WNLSF field)</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>utcDn</name>
+          <type>U1</type>
+          <comment>Day number at the end of which the future
+leap second becomes effective</comment>
+          <scale>-</scale>
+          <unit>days</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>utcDtLSF</name>
+          <type>I1</type>
+          <comment>Delta time due to future leap seconds</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-GPS-IONO</name>
+    <type>Input</type>
+    <description>GPS ionosphere assistance</description>
+    <comment>This message allows the delivery of GPS ionospheric assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x00</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x06 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ionoAlpha0</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha0 [s]</comment>
+          <scale>2^-30</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>ionoAlpha1</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha1 [s/semi-
+circle]</comment>
+          <scale>2^-27</scale>
+          <unit>s/semi-circle</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>ionoAlpha2</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha2 [s/semi-
+circle^2]</comment>
+          <scale>2^-24</scale>
+          <unit>s/(semi-circle^2)</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>ionoAlpha3</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter alpha3 [s/semi-
+circle^3]</comment>
+          <scale>2^-24</scale>
+          <unit>s/(semi-circle^3)</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ionoBeta0</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta0 [s]</comment>
+          <scale>2^11</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>ionoBeta1</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta1 [s/semi-
+circle]</comment>
+          <scale>2^14</scale>
+          <unit>s/semi-circle</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>ionoBeta2</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta2 [s/semi-
+circle^2]</comment>
+          <scale>2^16</scale>
+          <unit>s/(semi-circle^2)</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>ionoBeta3</name>
+          <type>I1</type>
+          <comment>Ionospheric parameter beta3 [s/semi-
+circle^3]</comment>
+          <scale>2^16</scale>
+          <unit>s/(semi-circle^3)</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-POS_XYZ</name>
+    <type>Input</type>
+    <description>Initial position assistance</description>
+    <comment>Supplying position assistance that is inaccurate by more than the specified position accuracy, may lead to substantially degraded receiver performance. This message allows the delivery of initial position assistance to a receiver in cartesian ECEF coordinates. This message is equivalent to the UBX-MGA-INI- POS_LLH message, except for the coordinate system. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x00 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ecefX</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF X coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefY</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Y coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefZ</name>
+          <type>I4</type>
+          <comment>WGS84 ECEF Z coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>posAcc</name>
+          <type>U4</type>
+          <comment>Position accuracy (stddev)</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-POS_LLH</name>
+    <type>Input</type>
+    <description>Initial position assistance</description>
+    <comment>Supplying position assistance that is inaccurate by more than the specified position accuracy, may lead to substantially degraded receiver performance. This message allows the delivery of initial position assistance to a receiver in WGS84 lat/long/alt coordinates. This message is equivalent to the UBX-MGA- INI-POS_XYZ message, except for the coordinate system. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>WGS84 Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>WGS84 Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>alt</name>
+          <type>I4</type>
+          <comment>WGS84 Altitude</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>posAcc</name>
+          <type>U4</type>
+          <comment>Position accuracy (stddev)</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-TIME_UTC</name>
+    <type>Input</type>
+    <description>Initial time assistance</description>
+    <comment>Supplying time assistance that is inaccurate by more than the specified time accuracy, may lead to substantially degraded receiver performance. This message allows the delivery of UTC time assistance to a receiver. This message is equivalent to the UBX-MGA-INI-TIME_GNSS message, except for the time base. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>24</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x10 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>ref</name>
+          <type>X1</type>
+          <comment>Reference to be used to set time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>source</name>
+              <description>0: none, i.e. on receipt of message (will be inaccurate!)
+1: relative to pulse sent to EXTINT0
+2: relative to pulse sent to EXTINT1
+3-15: reserved</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>fall</name>
+              <description>use falling edge of EXTINT pulse (default rising) - only if source is EXTINT</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>last</name>
+              <description>use last EXTINT pulse (default next pulse) - only if source is EXTINT</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>leapSecs</name>
+          <type>I1</type>
+          <comment>Number of leap seconds since 1980 (or
+0x80 = -128 if unknown)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month, starting at 1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day, starting at 1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour, from 0 to 23</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>minute</name>
+          <type>U1</type>
+          <comment>Minute, from 0 to 59</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>second</name>
+          <type>U1</type>
+          <comment>Seconds, from 0 to 59</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ns</name>
+          <type>U4</type>
+          <comment>Nanoseconds, from 0 to 999,999,999</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tAccS</name>
+          <type>U2</type>
+          <comment>Seconds part of time accuracy</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>tAccNs</name>
+          <type>U4</type>
+          <comment>Nanoseconds part of time accuracy, from
+0 to 999,999,999</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-TIME_GNSS</name>
+    <type>Input</type>
+    <description>Initial time assistance</description>
+    <comment>Supplying time assistance that is inaccurate by more than the specified time accuracy, may lead to substantially degraded receiver performance. This message allows the delivery of time assistance to a receiver in a chosen GNSS timebase. This message is equivalent to the UBX-MGA-INI-TIME_UTC message, except for the time base. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>24</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x11 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>ref</name>
+          <type>X1</type>
+          <comment>Reference to be used to set time</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>source</name>
+              <description>0: none, i.e. on receipt of message (will be inaccurate!)
+1: relative to pulse sent to EXTINT0
+2: relative to pulse sent to EXTINT1
+3-15: reserved</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>fall</name>
+              <description>use falling edge of EXTINT pulse (default rising) - only if source is EXTINT</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>last</name>
+              <description>use last EXTINT pulse (default next pulse) - only if source is EXTINT</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>gnssId</name>
+          <type>U1</type>
+          <comment>Source of time information. Currently
+supported:
+0: GPS time
+2: Galileo time
+3: BeiDou time
+6: GLONASS time: week = 834 + ((N4-
+1)*1461 + Nt)/7, tow = (((N4-1)*1461 + Nt) %
+7) * 86400 + tod</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>week</name>
+          <type>U2</type>
+          <comment>GNSS week number</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>tow</name>
+          <type>U4</type>
+          <comment>GNSS time of week</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ns</name>
+          <type>U4</type>
+          <comment>GNSS time of week, nanosecond part from
+0 to 999,999,999</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tAccS</name>
+          <type>U2</type>
+          <comment>Seconds part of time accuracy</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>tAccNs</name>
+          <type>U4</type>
+          <comment>Nanoseconds part of time accuracy, from
+0 to 999,999,999</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-CLKD</name>
+    <type>Input</type>
+    <description>Initial clock drift assistance</description>
+    <comment>Supplying clock drift assistance that is inaccurate by more than the specified accuracy, may lead to substantially degraded receiver performance. This message allows the delivery of clock drift assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x20 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>clkD</name>
+          <type>I4</type>
+          <comment>Clock drift</comment>
+          <scale>-</scale>
+          <unit>ns/s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>clkDAcc</name>
+          <type>U4</type>
+          <comment>Clock drift accuracy</comment>
+          <scale>-</scale>
+          <unit>ns/s</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-FREQ</name>
+    <type>Input</type>
+    <description>Initial frequency assistance</description>
+    <comment>Supplying external frequency assistance that is inaccurate by more than the specified accuracy, may lead to substantially degraded receiver performance. This message allows the delivery of external frequency assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x21 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Frequency reference</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>source</name>
+              <description>0: frequency available on EXTINT0
+1: frequency available on EXTINT1
+2-15: reserved</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>fall</name>
+              <description>use falling edge of EXTINT pulse (default rising)</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>freq</name>
+          <type>I4</type>
+          <comment>Frequency</comment>
+          <scale>1e-2</scale>
+          <unit>Hz</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>freqAcc</name>
+          <type>U4</type>
+          <comment>Frequency accuracy</comment>
+          <scale>-</scale>
+          <unit>ppb</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-INI-EOP</name>
+    <type>Input</type>
+    <description>Earth orientation parameters assistance</description>
+    <comment>This message allows the delivery of new earth orientation parameters (EOP) to a receiver to improve AssistNow Autonomous operation.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x40</id>
+      <length>72</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x30 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>d2kRef</name>
+          <type>U2</type>
+          <comment>reference time (days since 1.1.2000 12.00h
+UTC)</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>d2kMax</name>
+          <type>U2</type>
+          <comment>expiration time (days since 1.1.2000 12.00h
+UTC)</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>xpP0</name>
+          <type>I4</type>
+          <comment>x_p t^0 polynomial term (offset)</comment>
+          <scale>2^-30</scale>
+          <unit>arcsec</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>xpP1</name>
+          <type>I4</type>
+          <comment>x_p t^1 polynomial term (drift)</comment>
+          <scale>2^-30</scale>
+          <unit>arcsec/d</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>ypP0</name>
+          <type>I4</type>
+          <comment>y_p t^0 polynomial term (offset)</comment>
+          <scale>2^-30</scale>
+          <unit>arcsec</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>ypP1</name>
+          <type>I4</type>
+          <comment>y_p t^1 polynomial term (drift)</comment>
+          <scale>2^-30</scale>
+          <unit>arcsec/d</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>dUT1</name>
+          <type>I4</type>
+          <comment>dUT1 t^0 polynomial term (offset)</comment>
+          <scale>2^-25</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>ddUT1</name>
+          <type>I4</type>
+          <comment>dUT1 t^1 polynomial term (drift)</comment>
+          <scale>2^-30</scale>
+          <unit>s/d</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved2</name>
+          <type>U1[40]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-QZSS-EPH</name>
+    <type>Input</type>
+    <description>QZSS ephemeris assistance</description>
+    <comment>This message allows the delivery of QZSS ephemeris assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x05</id>
+      <length>68</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>QZSS Satellite identifier (see Satellite
+Numbering), Range 1-5</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>fitInterval</name>
+          <type>U1</type>
+          <comment>Fit interval flag</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>uraIndex</name>
+          <type>U1</type>
+          <comment>URA index</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>svHealth</name>
+          <type>U1</type>
+          <comment>SV health</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>tgd</name>
+          <type>I1</type>
+          <comment>Group delay differential</comment>
+          <scale>2^-31</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>iodc</name>
+          <type>U2</type>
+          <comment>IODC</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>toc</name>
+          <type>U2</type>
+          <comment>Clock data reference time</comment>
+          <scale>2^4</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>af2</name>
+          <type>I1</type>
+          <comment>Time polynomial coefficient 2</comment>
+          <scale>2^-55</scale>
+          <unit>s/ssquared</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>af1</name>
+          <type>I2</type>
+          <comment>Time polynomial coefficient 1</comment>
+          <scale>2^-43</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>af0</name>
+          <type>I4</type>
+          <comment>Time polynomial coefficient 0</comment>
+          <scale>2^-31</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>crs</name>
+          <type>I2</type>
+          <comment>Crs</comment>
+          <scale>2^-5</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>deltaN</name>
+          <type>I2</type>
+          <comment>Mean motion difference from computed
+value</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>m0</name>
+          <type>I4</type>
+          <comment>Mean anomaly at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>cuc</name>
+          <type>I2</type>
+          <comment>Amp of cosine harmonic corr term to arg
+of lat</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>cus</name>
+          <type>I2</type>
+          <comment>Amp of sine harmonic corr term to arg of
+lat</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>e</name>
+          <type>U4</type>
+          <comment>eccentricity</comment>
+          <scale>2^-33</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Square root of the semi-major axis A</comment>
+          <scale>2^-19</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>toe</name>
+          <type>U2</type>
+          <comment>Reference time of ephemeris</comment>
+          <scale>2^4</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>42</offset>
+          <name>cic</name>
+          <type>I2</type>
+          <comment>Amp of cos harmonic corr term to angle of
+inclination</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>omega0</name>
+          <type>I4</type>
+          <comment>Long of asc node of orbit plane at weekly
+epoch</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>cis</name>
+          <type>I2</type>
+          <comment>Amp of sine harmonic corr term to angle
+of inclination</comment>
+          <scale>2^-29</scale>
+          <unit>radians</unit>
+        </block>
+        <block>
+          <offset>50</offset>
+          <name>crc</name>
+          <type>I2</type>
+          <comment>Amp of cosine harmonic corr term to orbit
+radius</comment>
+          <scale>2^-5</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>i0</name>
+          <type>I4</type>
+          <comment>Inclination angle at reference time</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Argument of perigee</comment>
+          <scale>2^-31</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>omegaDot</name>
+          <type>I4</type>
+          <comment>Rate of right ascension</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>idot</name>
+          <type>I2</type>
+          <comment>Rate of inclination angle</comment>
+          <scale>2^-43</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>66</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-QZSS-ALM</name>
+    <type>Input</type>
+    <description>QZSS almanac assistance</description>
+    <comment>This message allows the delivery of QZSS almanac assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x05</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>QZSS Satellite identifier (see Satellite
+Numbering), Range 1-5</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>svHealth</name>
+          <type>U1</type>
+          <comment>Almanac SV health information</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>e</name>
+          <type>U2</type>
+          <comment>Almanac eccentricity</comment>
+          <scale>2^-21</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>almWNa</name>
+          <type>U1</type>
+          <comment>Reference week number of almanac (the
+8-bit WNa field)</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>toa</name>
+          <type>U1</type>
+          <comment>Reference time of almanac</comment>
+          <scale>2^12</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>deltaI</name>
+          <type>I2</type>
+          <comment>Delta inclination angle at reference time</comment>
+          <scale>2^-19</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>omegaDot</name>
+          <type>I2</type>
+          <comment>Almanac rate of right ascension</comment>
+          <scale>2^-38</scale>
+          <unit>semi-circles/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>sqrtA</name>
+          <type>U4</type>
+          <comment>Almanac square root of the semi-major
+axis A</comment>
+          <scale>2^-11</scale>
+          <unit>m^0.5</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>omega0</name>
+          <type>I4</type>
+          <comment>Almanac long of asc node of orbit plane at
+weekly</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>omega</name>
+          <type>I4</type>
+          <comment>Almanac argument of perigee</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>m0</name>
+          <type>I4</type>
+          <comment>Almanac mean anomaly at reference time</comment>
+          <scale>2^-23</scale>
+          <unit>semi-circles</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>af0</name>
+          <type>I2</type>
+          <comment>Almanac time polynomial coefficient 0 (8
+MSBs)</comment>
+          <scale>2^-20</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>af1</name>
+          <type>I2</type>
+          <comment>Almanac time polynomial coefficient 1</comment>
+          <scale>2^-38</scale>
+          <unit>s/s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MGA-QZSS-HEALTH</name>
+    <type>Input</type>
+    <description>QZSS health assistance</description>
+    <comment>This message allows the delivery of QZSS health assistance to a receiver. See the description of AssistNow Online for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x13</class>
+      <id>0x05</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x04 for this type)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>healthCode</name>
+          <type>U1[5]</type>
+          <comment>Each byte represents a QZSS SV (1-5). The
+6 LSBs of each byte contains the 6 bit
+health code from subframes 4/5, data ID =
+3, SV ID = 51</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>reserved2</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-BATCH</name>
+    <type>Polled</type>
+    <description>Data batching buffer status</description>
+    <comment>This message contains status information about the batching buffer. It can be polled and it can also be sent by the receiver as a response to a UBX- LOG-RETRIEVEBATCH message before the UBX-LOG-BATCH messages. See Data Batching for more information.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x32</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>fillLevel</name>
+          <type>U2</type>
+          <comment>Current buffer fill level, i.e. number of
+epochs currently stored</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>dropsAll</name>
+          <type>U2</type>
+          <comment>Number of dropped epochs since startup
+Note: changing the batching configuration
+will reset this counter.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>dropsSinceMon</name>
+          <type>U2</type>
+          <comment>Number of dropped epochs since last
+MON-BATCH message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>nextMsgCnt</name>
+          <type>U2</type>
+          <comment>The next retrieved UBX-LOG-BATCH will
+have this msgCnt value.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-GNSS</name>
+    <type>Polled</type>
+    <description>Information message major GNSS selection</description>
+    <comment>This message reports major GNSS selection. It does this by means of bit masks in U1 fields. Each bit in a bit mask corresponds to one major GNSS. Augmentation systems are not reported.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x28</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>supported</name>
+          <type>X1</type>
+          <comment>A bit mask showing the major GNSS that
+can be supported by this receiver</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>GPSSup</name>
+              <description>GPS is supported</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>GlonassSup</name>
+              <description>GLONASS is supported</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>BeidouSup</name>
+              <description>BeiDou is supported</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>GalileoSup</name>
+              <description>Galileo is supported</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>defaultGnss</name>
+          <type>X1</type>
+          <comment>A bit mask showing the default major
+GNSS selection. If the default major GNSS
+selection is currently configured in the
+efuse for this receiver, it takes precedence
+over the default major GNSS selection
+configured in the executing firmware of
+this receiver.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>GPSDef</name>
+              <description>GPS is default-enabled</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>GlonassDef</name>
+              <description>GLONASS is default-enabled</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>BeidouDef</name>
+              <description>BeiDou is default-enabled</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>GalileoDef</name>
+              <description>Galileo is default-enabled</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>enabled</name>
+          <type>X1</type>
+          <comment>A bit mask showing the current major
+GNSS selection enabled for this receiver</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>GPSEna</name>
+              <description>GPS is enabled</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>GlonassEna</name>
+              <description>GLONASS is enabled</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>BeidouEna</name>
+              <description>BeiDou is enabled</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>GalileoEna</name>
+              <description>Galileo is enabled</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>simultaneous</name>
+          <type>U1</type>
+          <comment>Maximum number of concurrent major
+GNSS that can be supported by this
+receiver</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-HW2</name>
+    <type>Periodic/Polled</type>
+    <description>Extended hardware status</description>
+    <comment>Status of different aspects of the hardware such as Imbalance, Low-Level Configuration and POST Results. The first four parameters of this message represent the complex signal from the RF front end. The following rules of thumb apply:  The smaller the absolute value of the variable ofsI and ofsQ, the better.  Ideally, the magnitude of the I-part (magI) and the Q-part (magQ) of the complex  signal should be the same.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x0B</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>ofsI</name>
+          <type>I1</type>
+          <comment>Imbalance of I-part of complex signal,
+scaled (-128 = max. negative imbalance,
+127 = max. positive imbalance)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>magI</name>
+          <type>U1</type>
+          <comment>Magnitude of I-part of complex signal,
+scaled (0 = no signal, 255 = max.
+magnitude)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>ofsQ</name>
+          <type>I1</type>
+          <comment>Imbalance of Q-part of complex signal,
+scaled (-128 = max. negative imbalance,
+127 = max. positive imbalance)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>magQ</name>
+          <type>U1</type>
+          <comment>Magnitude of Q-part of complex signal,
+scaled (0 = no signal, 255 = max.
+magnitude)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>cfgSource</name>
+          <type>U1</type>
+          <comment>Source of low-level configuration
+(114 = ROM, 111 = OTP, 112 = config pins,
+102 = flash image)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>lowLevCfg</name>
+          <type>U4</type>
+          <comment>Low-level configuration (obsolete in
+protocol versions greater than 15)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>reserved2</name>
+          <type>U1[8]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>postStatus</name>
+          <type>U4</type>
+          <comment>POST status word</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>reserved3</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-HW</name>
+    <type>Periodic/polled</type>
+    <description>Hardware status</description>
+    <comment>Status of different aspect of the hardware, such as antenna, PIO/peripheral pins, noise level, automatic gain control (AGC)</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x09</id>
+      <length>60</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>pinSel</name>
+          <type>X4</type>
+          <comment>Mask of pins set as peripheral/PIO</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>pinBank</name>
+          <type>X4</type>
+          <comment>Mask of pins set as bank A/B</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>pinDir</name>
+          <type>X4</type>
+          <comment>Mask of pins set as input/output</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>pinVal</name>
+          <type>X4</type>
+          <comment>Mask of pins value low/high</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>noisePerMS</name>
+          <type>U2</type>
+          <comment>Noise level as measured by the GPS core</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>agcCnt</name>
+          <type>U2</type>
+          <comment>AGC monitor (counts SIGHI xor SIGLO,
+range 0 to 8191)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>aStatus</name>
+          <type>U1</type>
+          <comment>Status of the antenna supervisor state
+machine (0=INIT, 1=DONTKNOW, 2=OK,
+3=SHORT, 4=OPEN)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>21</offset>
+          <name>aPower</name>
+          <type>U1</type>
+          <comment>Current power status of antenna (0=OFF,
+1=ON, 2=DONTKNOW)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>rtcCalib</name>
+              <description>RTC is calibrated</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>safeBoot</name>
+              <description>Safeboot mode (0 = inactive, 1 = active)</description>
+            </type>
+            <type>
+              <index>2:3</index>
+              <type>unsigned value</type>
+              <name>jammingState</name>
+              <description>Output from jamming/interference monitor (0 = unknown or feature disabled, 1 = ok - no significant
+jamming, 2 = warning - interference visible but fix OK, 3 = critical - interference visible and no fix)</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>xtalAbsent</name>
+              <description>RTC xtal has been determined to be absent (not supported in protocol versions less than 18)</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>usedMask</name>
+          <type>X4</type>
+          <comment>Mask of pins that are used by the virtual
+pin manager</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>VP</name>
+          <type>U1[17]</type>
+          <comment>Array of pin mappings for each of the 17
+physical pins</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>45</offset>
+          <name>jamInd</name>
+          <type>U1</type>
+          <comment>CW jamming indicator, scaled (0 = no CW
+jamming, 255 = strong CW jamming)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>46</offset>
+          <name>reserved2</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>pinIrq</name>
+          <type>X4</type>
+          <comment>Mask of pins value using the PIO Irq</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>pullH</name>
+          <type>X4</type>
+          <comment>Mask of pins value using the PIO pull high
+resistor</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>pullL</name>
+          <type>X4</type>
+          <comment>Mask of pins value using the PIO pull low
+resistor</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-IO</name>
+    <type>Periodic/Polled</type>
+    <description>I/O system status</description>
+    <comment>The size of the message is determined by the number of ports 'N' the receiver supports, i.e. on u-blox 5 the number of ports is 6.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x02</id>
+      <length>0 + 20*N</length>
+      <payload>
+        <block name="N" type="repeated">
+          <block>
+            <offset>N*20</offset>
+            <name>rxBytes</name>
+            <type>U4</type>
+            <comment>Number of bytes ever received</comment>
+            <scale>-</scale>
+            <unit>bytes</unit>
+          </block>
+          <block>
+            <offset>4 + 20*N</offset>
+            <name>txBytes</name>
+            <type>U4</type>
+            <comment>Number of bytes ever sent</comment>
+            <scale>-</scale>
+            <unit>bytes</unit>
+          </block>
+          <block>
+            <offset>8 + 20*N</offset>
+            <name>parityErrs</name>
+            <type>U2</type>
+            <comment>Number of 100 ms timeslots with parity
+errors</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>10 + 20*N</offset>
+            <name>framingErrs</name>
+            <type>U2</type>
+            <comment>Number of 100 ms timeslots with framing
+errors</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>12 + 20*N</offset>
+            <name>overrunErrs</name>
+            <type>U2</type>
+            <comment>Number of 100 ms timeslots with overrun
+errors</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>14 + 20*N</offset>
+            <name>breakCond</name>
+            <type>U2</type>
+            <comment>Number of 100 ms timeslots with break
+conditions</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>16 + 20*N</offset>
+            <name>reserved1</name>
+            <type>U1[4]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-MSGPP</name>
+    <type>Periodic/Polled</type>
+    <description>Message parse and process status</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x06</id>
+      <length>120</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>msg1</name>
+          <type>U2[8]</type>
+          <comment>Number of successfully parsed messages
+for each protocol on port0</comment>
+          <scale>-</scale>
+          <unit>msgs</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>msg2</name>
+          <type>U2[8]</type>
+          <comment>Number of successfully parsed messages
+for each protocol on port1</comment>
+          <scale>-</scale>
+          <unit>msgs</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>msg3</name>
+          <type>U2[8]</type>
+          <comment>Number of successfully parsed messages
+for each protocol on port2</comment>
+          <scale>-</scale>
+          <unit>msgs</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>msg4</name>
+          <type>U2[8]</type>
+          <comment>Number of successfully parsed messages
+for each protocol on port3</comment>
+          <scale>-</scale>
+          <unit>msgs</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>msg5</name>
+          <type>U2[8]</type>
+          <comment>Number of successfully parsed messages
+for each protocol on port4</comment>
+          <scale>-</scale>
+          <unit>msgs</unit>
+        </block>
+        <block>
+          <offset>80</offset>
+          <name>msg6</name>
+          <type>U2[8]</type>
+          <comment>Number of successfully parsed messages
+for each protocol on port5</comment>
+          <scale>-</scale>
+          <unit>msgs</unit>
+        </block>
+        <block>
+          <offset>96</offset>
+          <name>skipped</name>
+          <type>U4[6]</type>
+          <comment>Number skipped bytes for each port</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-PATCH</name>
+    <type>Poll Request</type>
+    <description>Poll request for installed patches</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x27</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-PATCH</name>
+    <type>Polled</type>
+    <description>Installed patches</description>
+    <comment>This message reports information about patches installed and currently enabled on the receiver. It does not report on patches installed and then disabled. An enabled patch is considered active when the receiver executes from the code space where the patch resides on. For example, a ROM patch is reported active only when the system runs from ROM.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x27</id>
+      <length>4 + 16*nEntries</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U2</type>
+          <comment>Message version (0x0001 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>nEntries</name>
+          <type>U2</type>
+          <comment>Total number of reported patches</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="nEntries" type="repeated">
+          <block>
+            <offset>4 + 16*N</offset>
+            <name>patchInfo</name>
+            <type>X4</type>
+            <comment>Status information about the reported
+patch</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>activated</name>
+                <description>1: the patch is active, 0: otherwise</description>
+              </type>
+              <type>
+                <index>1:2</index>
+                <type>unsigned value</type>
+                <name>location</name>
+                <description>Indicates where the patch is stored. 0: eFuse, 1: ROM, 2: BBR, 3: file system</description>
+              </type>
+              <type>
+                <index>3:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>8 + 16*N</offset>
+            <name>comparatorNumber</name>
+            <type>U4</type>
+            <comment>The number of the comparator</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>12 + 16*N</offset>
+            <name>patchAddress</name>
+            <type>U4</type>
+            <comment>The address that is targeted by the patch</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>16 + 16*N</offset>
+            <name>patchData</name>
+            <type>U4</type>
+            <comment>The data that is inserted at the
+patchAddress</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-RXBUF</name>
+    <type>Periodic/Polled</type>
+    <description>Receiver buffer status</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x07</id>
+      <length>24</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>pending</name>
+          <type>U2[6]</type>
+          <comment>Number of bytes pending in receiver
+buffer for each target</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>usage</name>
+          <type>U1[6]</type>
+          <comment>Maximum usage receiver buffer during the
+last sysmon period for each target</comment>
+          <scale>-</scale>
+          <unit>%</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>peakUsage</name>
+          <type>U1[6]</type>
+          <comment>Maximum usage receiver buffer for each
+target</comment>
+          <scale>-</scale>
+          <unit>%</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-RXR</name>
+    <type>Output</type>
+    <description>Receiver status information</description>
+    <comment>The receiver ready message is sent when the receiver changes from or to backup mode.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x21</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Receiver status flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>awake</name>
+              <description>not in backup mode</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-SMGR</name>
+    <type>Periodic/Polled</type>
+    <description>Synchronization manager status</description>
+    <comment>This message reports the status of internal and external oscillators and sources as well as whether GNSS is used for disciplining.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x2E</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>Time of the week</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>intOsc</name>
+          <type>X2</type>
+          <comment>A bit mask, indicating the status of the
+local oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>intOscState</name>
+              <description>State of the oscillator:
+0: autonomous operation
+1: calibration ongoing
+2: oscillator is steered by the host
+3: idle state</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>intOscCalib</name>
+              <description>1 = oscillator gain is calibrated</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>intOscDisc</name>
+              <description>1 = signal is disciplined</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>extOsc</name>
+          <type>X2</type>
+          <comment>A bit mask, indicating the status of the
+external oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>extOscState</name>
+              <description>State of the oscillator:
+0: autonomous operation
+1: calibration ongoing
+2: oscillator is steered by the host
+3: idle state</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>extOscCalib</name>
+              <description>1 = oscillator gain is calibrated</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>extOscDisc</name>
+              <description>1 = signal is disciplined</description>
+            </type>
+            <type>
+              <index>6:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>discSrc</name>
+          <type>U1</type>
+          <comment>Disciplining source identifier:
+0: internal oscillator
+1: GNSS
+2: EXTINT0
+3: EXTINT1
+4: internal oscillator measured by the host
+5: external oscillator measured by the host</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>gnss</name>
+          <type>X1</type>
+          <comment>A bit mask, indicating the status of the
+GNSS</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gnssAvail</name>
+              <description>1 = GNSS is present</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>extInt0</name>
+          <type>X1</type>
+          <comment>A bit mask, indicating the status of the
+external input 0</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>extInt0Avail</name>
+              <description>1 = signal present at this input</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>extInt0Type</name>
+              <description>Source type:
+0: frequency
+1: time</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>extInt0FeedBack</name>
+              <description>This source is used as feedback of the external oscillator</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>extInt1</name>
+          <type>X1</type>
+          <comment>A bit mask, indicating the status of the
+external input 1</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>extInt1Avail</name>
+              <description>1 = signal present at this input</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>extInt1Type</name>
+              <description>Source type:
+0: frequency
+1: time</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>extInt1FeedBack</name>
+              <description>This source is used as feedback of the external oscillator</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-TXBUF</name>
+    <type>Periodic/Polled</type>
+    <description>Transmitter buffer status</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x08</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>pending</name>
+          <type>U2[6]</type>
+          <comment>Number of bytes pending in transmitter
+buffer for each target</comment>
+          <scale>-</scale>
+          <unit>bytes</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>usage</name>
+          <type>U1[6]</type>
+          <comment>Maximum usage transmitter buffer during
+the last sysmon period for each target</comment>
+          <scale>-</scale>
+          <unit>%</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>peakUsage</name>
+          <type>U1[6]</type>
+          <comment>Maximum usage transmitter buffer for
+each target</comment>
+          <scale>-</scale>
+          <unit>%</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>tUsage</name>
+          <type>U1</type>
+          <comment>Maximum usage of transmitter buffer
+during the last sysmon period for all
+targets</comment>
+          <scale>-</scale>
+          <unit>%</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>tPeakusage</name>
+          <type>U1</type>
+          <comment>Maximum usage of transmitter buffer for
+all targets</comment>
+          <scale>-</scale>
+          <unit>%</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>errors</name>
+          <type>X1</type>
+          <comment>Error bitmask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:5</index>
+              <type>unsigned value</type>
+              <name>limit</name>
+              <description>Buffer limit of corresponding target reached</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>mem</name>
+              <description>Memory Allocation error</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>alloc</name>
+              <description>Allocation error (TX buffer full)</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-VER</name>
+    <type>Poll Request</type>
+    <description>Poll receiver and software version</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x04</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-MON-VER</name>
+    <type>Polled</type>
+    <description>Receiver and software version</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x04</id>
+      <length>40 + 30*N</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>swVersion</name>
+          <type>CH[30]</type>
+          <comment>Nul-terminated software version string.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>hwVersion</name>
+          <type>CH[10]</type>
+          <comment>Nul-terminated hardware version string</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="N" type="repeated">
+          <block>
+            <offset>40 + 30*N</offset>
+            <name>extension</name>
+            <type>CH[30]</type>
+            <comment>Extended software information strings.
+A series of nul-terminated strings. Each
+extension field is 30 characters long and
+contains varying software information.
+Not all extension fields may appear.
+Examples of reported information: the
+software version string of the underlying
+ROM (when the receiver's firmware is
+running from flash), the firmware version,
+the supported protocol version, the
+module identifier, the flash information
+structure (FIS) file information, the
+supported major GNSS, the supported
+augmentation systems.
+See Firmware and protocol versions for
+details.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-AOPSTATUS</name>
+    <type>Periodic/Polled</type>
+    <description>AssistNow Autonomous status</description>
+    <comment>This message provides information on the status of the AssistNow Autonomous subsystem on the receiver. For example, a host application can determine the optimal time to shut down the receiver by monitoring the status field for a steady 0. See the chapter AssistNow Autonomous in the receiver description for details on this feature.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x60</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>aopCfg</name>
+          <type>U1</type>
+          <comment>AssistNow Autonomous configuration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>useAOP</name>
+              <description>AOP enabled flag</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>status</name>
+          <type>U1</type>
+          <comment>AssistNow Autonomous subsystem is idle
+(0) or running (not 0)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved1</name>
+          <type>U1[10]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-ATT</name>
+    <type>Periodic/Polled</type>
+    <description>Attitude solution</description>
+    <comment>This message outputs the attitude solution as roll, pitch and heading angles. More details about vehicle attitude can be found in the Vehicle Attitude Output (ADR) section for ADR products. More details about vehicle attitude can be found in the Vehicle Attitude Output (UDR) section for UDR products.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x05</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>roll</name>
+          <type>I4</type>
+          <comment>Vehicle roll.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>pitch</name>
+          <type>I4</type>
+          <comment>Vehicle pitch.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>heading</name>
+          <type>I4</type>
+          <comment>Vehicle heading.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>accRoll</name>
+          <type>U4</type>
+          <comment>Vehicle roll accuracy (if null, roll angle is
+not available).</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>accPitch</name>
+          <type>U4</type>
+          <comment>Vehicle pitch accuracy (if null, pitch angle
+is not available).</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>accHeading</name>
+          <type>U4</type>
+          <comment>Vehicle heading accuracy (if null, heading
+angle is not available).</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-CLOCK</name>
+    <type>Periodic/Polled</type>
+    <description>Clock solution</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x22</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>clkB</name>
+          <type>I4</type>
+          <comment>Clock bias</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>clkD</name>
+          <type>I4</type>
+          <comment>Clock drift</comment>
+          <scale>-</scale>
+          <unit>ns/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>fAcc</name>
+          <type>U4</type>
+          <comment>Frequency accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>ps/s</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-DGPS</name>
+    <type>Periodic/Polled</type>
+    <description>DGPS data used for NAV</description>
+    <comment>This message outputs the DGPS correction data that has been applied to the current NAV Solution. See also the notes on the RTCM protocol.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x31</id>
+      <length>16 + 12*numCh</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>age</name>
+          <type>I4</type>
+          <comment>Age of newest correction data</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>baseId</name>
+          <type>I2</type>
+          <comment>DGPS base station identifier</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>baseHealth</name>
+          <type>I2</type>
+          <comment>DGPS base station health status</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>numCh</name>
+          <type>U1</type>
+          <comment>Number of channels for which correction
+data is following</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>status</name>
+          <type>U1</type>
+          <comment>DGPS correction type status:
+0x00:   none
+0x01:  PR+PRR correction</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numCh" type="repeated">
+          <block>
+            <offset>16 + 12*N</offset>
+            <name>svid</name>
+            <type>U1</type>
+            <comment>Satellite ID</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>17 + 12*N</offset>
+            <name>flags</name>
+            <type>X1</type>
+            <comment>Channel number and usage</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>channel</name>
+                <description>GPS channel number this SV is on. Channel numbers in the firmware greater than 15 are displayed as
+having channel number 15</description>
+              </type>
+              <type>
+                <index>4</index>
+                <type>unsigned value</type>
+                <name>dgpsUsed</name>
+                <description>1 = DGPS used for this SV</description>
+              </type>
+              <type>
+                <index>5:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>18 + 12*N</offset>
+            <name>ageC</name>
+            <type>U2</type>
+            <comment>Age of latest correction data</comment>
+            <scale>-</scale>
+            <unit>ms</unit>
+          </block>
+          <block>
+            <offset>20 + 12*N</offset>
+            <name>prc</name>
+            <type>R4</type>
+            <comment>Pseudorange correction</comment>
+            <scale>-</scale>
+            <unit>m</unit>
+          </block>
+          <block>
+            <offset>24 + 12*N</offset>
+            <name>prrc</name>
+            <type>R4</type>
+            <comment>Pseudorange rate correction</comment>
+            <scale>-</scale>
+            <unit>m/s</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-DOP</name>
+    <type>Periodic/Polled</type>
+    <description>Dilution of precision</description>
+    <comment>DOP values are dimensionless. All DOP values are scaled by a factor of 100. If the unit transmits a value of e.g. 156, the DOP value is 1.56.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x04</id>
+      <length>18</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>gDOP</name>
+          <type>U2</type>
+          <comment>Geometric DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>pDOP</name>
+          <type>U2</type>
+          <comment>Position DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>tDOP</name>
+          <type>U2</type>
+          <comment>Time DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>vDOP</name>
+          <type>U2</type>
+          <comment>Vertical DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>hDOP</name>
+          <type>U2</type>
+          <comment>Horizontal DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>nDOP</name>
+          <type>U2</type>
+          <comment>Northing DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>eDOP</name>
+          <type>U2</type>
+          <comment>Easting DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-EOE</name>
+    <type>Periodic</type>
+    <description>End of epoch</description>
+    <comment>This message is intended to be used as a marker to collect all navigation messages of an epoch. It is output after all enabled NAV class messages (except UBX-NAV-HNR) and after all enabled NMEA messages.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x61</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-GEOFENCE</name>
+    <type>Periodic/Polled</type>
+    <description>Geofencing status</description>
+    <comment>This message outputs the evaluated states of all configured geofences for the current epoch's position. See the Geofencing description for feature details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x39</id>
+      <length>8 + 2*numFences</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>status</name>
+          <type>U1</type>
+          <comment>Geofencing status
+0 - Geofencing not available or not reliable
+1 - Geofencing active</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>numFences</name>
+          <type>U1</type>
+          <comment>Number of geofences</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>combState</name>
+          <type>U1</type>
+          <comment>Combined (logical OR) state of all
+geofences
+0 - Unknown
+1 - Inside
+2 - Outside</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numFences" type="repeated">
+          <block>
+            <offset>8 + 2*N</offset>
+            <name>state</name>
+            <type>U1</type>
+            <comment>Geofence state
+0 - Unknown
+1 - Inside
+2 - Outside</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>9 + 2*N</offset>
+            <name>id</name>
+            <type>U1</type>
+            <comment>Geofence ID (0 = not available)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-HPPOSECEF</name>
+    <type>Periodic/Polled</type>
+    <description>High precision position solution in ECEF</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x13</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefX</name>
+          <type>I4</type>
+          <comment>ECEF X coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefY</name>
+          <type>I4</type>
+          <comment>ECEF Y coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>ecefZ</name>
+          <type>I4</type>
+          <comment>ECEF Z coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>ecefXHp</name>
+          <type>I1</type>
+          <comment>High precision component of ECEF X
+coordinate. Must be in the range of -99..
++99. Precise coordinate in cm = ecefX +
+(ecefXHp * 1e-2).</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>21</offset>
+          <name>ecefYHp</name>
+          <type>I1</type>
+          <comment>High precision component of ECEF Y
+coordinate. Must be in the range of -99..
++99. Precise coordinate in cm = ecefY +
+(ecefYHp * 1e-2).</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>ecefZHp</name>
+          <type>I1</type>
+          <comment>High precision component of ECEF Z
+coordinate. Must be in the range of -99..
++99. Precise coordinate in cm = ecefZ +
+(ecefZHp * 1e-2).</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Additional flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>invalidEcef</name>
+              <description>1 = Invalid ecefX, ecefY, ecefZ, ecefXHp, ecefYHp and ecefZHp</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>pAcc</name>
+          <type>U4</type>
+          <comment>Position Accuracy Estimate</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-HPPOSLLH</name>
+    <type>Periodic/Polled</type>
+    <description>High precision geodetic position solution</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters. This message outputs the Geodetic position with high precision in the currently selected ellipsoid. The default is the WGS84 Ellipsoid, but can be changed with the message UBX-CFG-DAT.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x14</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Additional flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>invalidLlh</name>
+              <description>1 = Invalid lon, lat, height, hMSL, lonHp, latHp, heightHp and hMSLHp</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>height</name>
+          <type>I4</type>
+          <comment>Height above ellipsoid.</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>hMSL</name>
+          <type>I4</type>
+          <comment>Height above mean sea level</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>lonHp</name>
+          <type>I1</type>
+          <comment>High precision component of longitude.
+Must be in the range -99..+99. Precise
+longitude in deg * 1e-7 = lon + (lonHp * 1e-
+2).</comment>
+          <scale>1e-9</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>latHp</name>
+          <type>I1</type>
+          <comment>High precision component of latitude.
+Must be in the range -99..+99. Precise
+latitude in deg * 1e-7 = lat + (latHp * 1e-2).</comment>
+          <scale>1e-9</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>heightHp</name>
+          <type>I1</type>
+          <comment>High precision component of height above
+ellipsoid. Must be in the range -9..+9.
+Precise height in mm = height + (heightHp
+* 0.1).</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>hMSLHp</name>
+          <type>I1</type>
+          <comment>High precision component of height above
+mean sea level. Must be in range -9..+9.
+Precise height in mm = hMSL + (hMSLHp *
+0.1)</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>hAcc</name>
+          <type>U4</type>
+          <comment>Horizontal accuracy estimate</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>vAcc</name>
+          <type>U4</type>
+          <comment>Vertical accuracy estimate</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-NMI</name>
+    <type>Periodic/Polled</type>
+    <description>Navigation message cross-check information</description>
+    <comment>Information about the validity of received satellite navigation payload.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 22.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x28</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>gpsNmiFlags</name>
+          <type>X1</type>
+          <comment>GPS navigation message cross-check
+information flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>wnoCheckedGPS</name>
+              <description>1 = week number check performed.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>wnoInvalidGPS</name>
+              <description>1 = week number invalid.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>gpsLsFlags</name>
+          <type>X1</type>
+          <comment>GPS leap second cross-check information
+flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>lsValGPS</name>
+              <description>1 = Leap second value out of range.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>dnRangeGPS</name>
+              <description>1 = Day number value out of range.</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>totRangeGPS</name>
+              <description>1 = Data reference ToW out of range.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>lsEventGPS</name>
+              <description>1 = Unexpected leap second event.</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>recNowGPS</name>
+              <description>1 = Data received this epoch.</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>galNmiFlags</name>
+          <type>X1</type>
+          <comment>Galileo navigation message cross-check
+information flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>wnoCheckedGAL</name>
+              <description>1 = week number check performed.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>wnoInvalidGAL</name>
+              <description>1 = week number invalid.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>galLsFlags</name>
+          <type>X1</type>
+          <comment>Galileo leap second cross-check
+information flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>lsValGAL</name>
+              <description>1 = Leap second value out of range.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>dnRangeGAL</name>
+              <description>1 = Day number value out of range.</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>totRangeGAL</name>
+              <description>1 = Data reference ToW out of range.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>lsEventGAL</name>
+              <description>1 = Unexpected leap second event.</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>recNowGAL</name>
+              <description>1 = Data received this epoch.</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>bdsNmiFlags</name>
+          <type>X1</type>
+          <comment>BeiDou navigation message cross-check
+information flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>wnoCheckedBDS</name>
+              <description>1 = week number check performed.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>wnoInvalidBDS</name>
+              <description>1 = week number invalid.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>bdsLsFlags</name>
+          <type>X1</type>
+          <comment>BeiDou leap second cross-check
+information flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>lsValBDS</name>
+              <description>1 = Leap second value out of range.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>dnRangeBDS</name>
+              <description>1 = Day number value out of range.</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>totRangeBDS</name>
+              <description>1 = Data reference ToW out of range.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>lsEventBDS</name>
+              <description>1 = Unexpected leap second event.</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>recNowBDS</name>
+              <description>1 = Data received this epoch.</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>gloNmiFlags</name>
+          <type>X1</type>
+          <comment>GLONASS navigation message cross-
+check information flags.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>wnoCheckedGLO</name>
+              <description>1 = week number check performed.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>wnoInvalidGLO</name>
+              <description>1 = week number invalid.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-ODO</name>
+    <type>Periodic/Polled</type>
+    <description>Odometer solution</description>
+    <comment>This message outputs the traveled distance since last reset (see UBX-NAV- RESETODO) together with an associated estimated accuracy and the total cumulated ground distance (can only be reset by a cold start of the receiver).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x09</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>distance</name>
+          <type>U4</type>
+          <comment>Ground distance since last reset</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>totalDistance</name>
+          <type>U4</type>
+          <comment>Total cumulative ground distance</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>distanceStd</name>
+          <type>U4</type>
+          <comment>Ground distance accuracy (1-sigma)</comment>
+          <scale>-</scale>
+          <unit>m</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-ORB</name>
+    <type>Periodic/Polled</type>
+    <description>GNSS orbit database info</description>
+    <comment>Status of the GNSS orbit database knowledge.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x34</id>
+      <length>8 + 6*numSv</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>numSv</name>
+          <type>U1</type>
+          <comment>Number of SVs in the database</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSv" type="repeated">
+          <block>
+            <offset>8 + 6*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>GNSS ID</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>9 + 6*N</offset>
+            <name>svId</name>
+            <type>U1</type>
+            <comment>Satellite ID</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>10 + 6*N</offset>
+            <name>svFlag</name>
+            <type>X1</type>
+            <comment>Information Flags</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:1</index>
+                <type>unsigned value</type>
+                <name>health</name>
+                <description>SV health:
+0: unknown
+1: healthy
+2: not healty</description>
+              </type>
+              <type>
+                <index>2:3</index>
+                <type>unsigned value</type>
+                <name>visibility</name>
+                <description>SV health:
+0: unknown
+1: below horizon
+2: above horizon
+3: above elevation mask</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>11 + 6*N</offset>
+            <name>eph</name>
+            <type>X1</type>
+            <comment>Ephemeris data</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:4</index>
+                <type>unsigned value</type>
+                <name>ephUsability</name>
+                <description>How long the receiver will be able to use the stored ephemeris data from now on:
+31: The usability period is unknown
+30: The usability period is more than 450 minutes
+30 &gt; n &gt; 0: The usability period is between (n-1)*15 and n*15 minutes
+0: Ephemeris can no longer be used</description>
+              </type>
+              <type>
+                <index>5:7</index>
+                <type>unsigned value</type>
+                <name>ephSource</name>
+                <description>0: not available
+1: GNSS transmission
+2: external aiding
+3-7: other</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>12 + 6*N</offset>
+            <name>alm</name>
+            <type>X1</type>
+            <comment>Almanac data</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:4</index>
+                <type>unsigned value</type>
+                <name>almUsability</name>
+                <description>How long the receiver will be able to use the stored almanac data from now on:
+31: The usability period is unknown
+30: The usability period is more than 30 days
+30 &gt; n &gt; 0: The usability period is between n-1 and n days
+0: Almanac can no longer be used</description>
+              </type>
+              <type>
+                <index>5:7</index>
+                <type>unsigned value</type>
+                <name>almSource</name>
+                <description>0: not available
+1: GNSS transmission
+2: external aiding
+3-7: other</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>13 + 6*N</offset>
+            <name>otherOrb</name>
+            <type>X1</type>
+            <comment>Other orbit data available</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:4</index>
+                <type>unsigned value</type>
+                <name>anoAopUsability</name>
+                <description>How long the receiver will be able to use the orbit data from now on: 31: The usability period is unknown
+30: The usability period is more than 30 days
+30 &gt; n &gt; 0: The usability period is between n-1 and n days
+0: Data can no longer be used</description>
+              </type>
+              <type>
+                <index>5:7</index>
+                <type>unsigned value</type>
+                <name>type</name>
+                <description>Type of orbit data:
+0: No orbit data available
+1: AssistNow Offline data
+2: AssistNow Autonomous data
+3-7: Other orbit data</description>
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-POSECEF</name>
+    <type>Periodic/Polled</type>
+    <description>Position solution in ECEF</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x01</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ecefX</name>
+          <type>I4</type>
+          <comment>ECEF X coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefY</name>
+          <type>I4</type>
+          <comment>ECEF Y coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefZ</name>
+          <type>I4</type>
+          <comment>ECEF Z coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>pAcc</name>
+          <type>U4</type>
+          <comment>Position Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-POSLLH</name>
+    <type>Periodic/Polled</type>
+    <description>Geodetic position solution</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters. This message outputs the Geodetic position in the currently selected ellipsoid. The default is the WGS84 Ellipsoid, but can be changed with the message UBX- CFG-DAT.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x02</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>height</name>
+          <type>I4</type>
+          <comment>Height above ellipsoid</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>hMSL</name>
+          <type>I4</type>
+          <comment>Height above mean sea level</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>hAcc</name>
+          <type>U4</type>
+          <comment>Horizontal accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>vAcc</name>
+          <type>U4</type>
+          <comment>Vertical accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-PVT</name>
+    <type>Periodic/Polled</type>
+    <description>Navigation position velocity time solution</description>
+    <comment>This message combines position, velocity and time solution, including accuracy figures. Note that during a leap second there may be more or less than 60 seconds in a minute. See the description of leap seconds for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x07</id>
+      <length>92</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year (UTC)</comment>
+          <scale>-</scale>
+          <unit>y</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month, range 1..12 (UTC)</comment>
+          <scale>-</scale>
+          <unit>month</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day of month, range 1..31 (UTC)</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour of day, range 0..23 (UTC)</comment>
+          <scale>-</scale>
+          <unit>h</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>min</name>
+          <type>U1</type>
+          <comment>Minute of hour, range 0..59 (UTC)</comment>
+          <scale>-</scale>
+          <unit>min</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>sec</name>
+          <type>U1</type>
+          <comment>Seconds of minute, range 0..60 (UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>validDate</name>
+              <description>1 = valid UTC Date (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>validTime</name>
+              <description>1 = valid UTC time of day (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>fullyResolved</name>
+              <description>1 = UTC time of day has been fully resolved (no seconds uncertainty). Cannot be used to check if time
+is completely solved.</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>validMag</name>
+              <description>1 = valid magnetic declination</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time accuracy estimate (UTC)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>nano</name>
+          <type>I4</type>
+          <comment>Fraction of second, range -1e9 .. 1e9 (UTC)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>fixType</name>
+          <type>U1</type>
+          <comment>GNSSfix Type:
+0: no fix
+1: dead reckoning only
+2: 2D-fix
+3: 3D-fix
+4: GNSS + dead reckoning combined
+5: time only fix</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>21</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Fix status flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gnssFixOK</name>
+              <description>1 = valid fix (i.e within DOP &amp; accuracy masks)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>diffSoln</name>
+              <description>1 = differential corrections were applied</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>headVehValid</name>
+              <description>1 = heading of vehicle is valid, only set if the receiver is in sensor fusion mode</description>
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>unsigned value</type>
+              <name>carrSoln</name>
+              <description>Carrier phase range solution status:
+0: no carrier phase range solution
+1: carrier phase range solution with floating ambiguities
+2: carrier phase range solution with fixed ambiguities
+(not supported in protocol versions less than 20)</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>flags2</name>
+          <type>X1</type>
+          <comment>Additional flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>confirmedAvai</name>
+              <description>1 = information about UTC Date and Time of Day validity confirmation is available (see Time Validity
+section for details)
+This flag is only supported in Protocol Versions 19.00, 19.10, 20.10, 20.20, 20.30, 22.00, 23.00, 23.01,
+27 and 28.</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>confirmedDate</name>
+              <description>1 = UTC Date validity could be confirmed (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>confirmedTime</name>
+              <description>1 = UTC Time of Day could be confirmed (see Time Validity section for details)</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Number of satellites used in Nav Solution</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>lon</name>
+          <type>I4</type>
+          <comment>Longitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>lat</name>
+          <type>I4</type>
+          <comment>Latitude</comment>
+          <scale>1e-7</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>height</name>
+          <type>I4</type>
+          <comment>Height above ellipsoid</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>hMSL</name>
+          <type>I4</type>
+          <comment>Height above mean sea level</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>hAcc</name>
+          <type>U4</type>
+          <comment>Horizontal accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>vAcc</name>
+          <type>U4</type>
+          <comment>Vertical accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>velN</name>
+          <type>I4</type>
+          <comment>NED north velocity</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>velE</name>
+          <type>I4</type>
+          <comment>NED east velocity</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>velD</name>
+          <type>I4</type>
+          <comment>NED down velocity</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>gSpeed</name>
+          <type>I4</type>
+          <comment>Ground Speed (2-D)</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>64</offset>
+          <name>headMot</name>
+          <type>I4</type>
+          <comment>Heading of motion (2-D)</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>68</offset>
+          <name>sAcc</name>
+          <type>U4</type>
+          <comment>Speed accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>mm/s</unit>
+        </block>
+        <block>
+          <offset>72</offset>
+          <name>headAcc</name>
+          <type>U4</type>
+          <comment>Heading accuracy estimate (both motion
+and vehicle)</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>76</offset>
+          <name>pDOP</name>
+          <type>U2</type>
+          <comment>Position DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>78</offset>
+          <name>flags3</name>
+          <type>X1</type>
+          <comment>Additional flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>invalidLlh</name>
+              <description>1 = Invalid lon, lat, height and hMSL</description>
+            </type>
+            <type>
+              <index>1:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>79</offset>
+          <name>reserved1</name>
+          <type>U1[5]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>84</offset>
+          <name>headVeh</name>
+          <type>I4</type>
+          <comment>Heading of vehicle (2-D), this is only valid
+when headVehValid is set, otherwise the
+output is set to the heading of motion</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>88</offset>
+          <name>magDec</name>
+          <type>I2</type>
+          <comment>Magnetic declination. Only supported in
+ADR 4.10 and later.</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>90</offset>
+          <name>magAcc</name>
+          <type>U2</type>
+          <comment>Magnetic declination accuracy. Only
+supported in ADR 4.10 and later.</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-RELPOSNED</name>
+    <type>Periodic/Polled</type>
+    <description>Relative positioning information in NED frame</description>
+    <comment>The NED frame is defined as the local topological system at the reference station. The relative position vector components in this message, along with their associated accuracies, are given in that local topological system. This message contains the relative position vector from the Reference Station to the Rover, including accuracy figures, in the local topological system defined at the reference station</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with High Precision GNSS products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x3C</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>refStationId</name>
+          <type>U2</type>
+          <comment>Reference Station ID. Must be in the range
+0..4095</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>relPosN</name>
+          <type>I4</type>
+          <comment>North component of relative position
+vector</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>relPosE</name>
+          <type>I4</type>
+          <comment>East component of relative position vector</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>relPosD</name>
+          <type>I4</type>
+          <comment>Down component of relative position
+vector</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>relPosHPN</name>
+          <type>I1</type>
+          <comment>High-precision North component of
+relative position vector.
+Must be in the range -99 to +99.
+The full North component of the relative
+position vector, in units of cm, is given by
+relPosN + (relPosHPN * 1e-2)</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>21</offset>
+          <name>relPosHPE</name>
+          <type>I1</type>
+          <comment>High-precision East component of relative
+position vector.
+Must be in the range -99 to +99.
+The full East component of the relative
+position vector, in units of cm, is given by
+relPosE + (relPosHPE * 1e-2)</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>relPosHPD</name>
+          <type>I1</type>
+          <comment>High-precision Down component of
+relative position vector.
+Must be in the range -99 to +99.
+The full Down component of the relative
+position vector, in units of cm, is given by
+relPosD + (relPosHPD * 1e-2)</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>accN</name>
+          <type>U4</type>
+          <comment>Accuracy of relative position North
+component</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>accE</name>
+          <type>U4</type>
+          <comment>Accuracy of relative position East
+component</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>accD</name>
+          <type>U4</type>
+          <comment>Accuracy of relative position Down
+component</comment>
+          <scale>0.1</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gnssFixOK</name>
+              <description>A valid fix (i.e within DOP &amp; accuracy masks)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>diffSoln</name>
+              <description>1 if differential corrections were applied</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>relPosValid</name>
+              <description>1 if relative position components and accuracies are valid</description>
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>unsigned value</type>
+              <name>carrSoln</name>
+              <description>Carrier phase range solution status:
+0 = no carrier phase range solution
+1 = carrier phase range solution with floating ambiguities
+2 = carrier phase range solution with fixed ambiguities</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>isMoving</name>
+              <description>1 if the receiver is operating in moving baseline mode (not supported in protocol versions less than
+20.3)</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>refPosMiss</name>
+              <description>1 if extrapolated reference position was used to compute moving baseline solution this epoch (not
+supported in protocol versions less than 20.3)</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>refObsMiss</name>
+              <description>1 if extrapolated reference observations were used to compute moving baseline solution this epoch
+(not supported in protocol versions less than 20.3)</description>
+            </type>
+            <type>
+              <index>8:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-RESETODO</name>
+    <type>Command</type>
+    <description>Reset odometer</description>
+    <comment>This message resets the traveled distance computed by the odometer (see UBX- NAV-ODO). UBX-ACK-ACK or UBX-ACK-NAK are returned to indicate success or failure.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x10</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-SAT</name>
+    <type>Periodic/Polled</type>
+    <description>Satellite information</description>
+    <comment>This message displays information about SVs that are either known to be visible or currently tracked by the receiver. All signal related information corresponds to the subset of signals specified in Signal Identifiers.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x35</id>
+      <length>8 + 12*numSvs</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>numSvs</name>
+          <type>U1</type>
+          <comment>Number of satellites</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSvs" type="repeated">
+          <block>
+            <offset>8 + 12*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>GNSS identifier (see Satellite Numbering)
+for assignment</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>9 + 12*N</offset>
+            <name>svId</name>
+            <type>U1</type>
+            <comment>Satellite identifier (see Satellite
+Numbering) for assignment</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>10 + 12*N</offset>
+            <name>cno</name>
+            <type>U1</type>
+            <comment>Carrier to noise ratio (signal strength)</comment>
+            <scale>-</scale>
+            <unit>dBHz</unit>
+          </block>
+          <block>
+            <offset>11 + 12*N</offset>
+            <name>elev</name>
+            <type>I1</type>
+            <comment>Elevation (range: +/-90), unknown if out of
+range</comment>
+            <scale>-</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>12 + 12*N</offset>
+            <name>azim</name>
+            <type>I2</type>
+            <comment>Azimuth (range 0-360), unknown if
+elevation is out of range</comment>
+            <scale>-</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>14 + 12*N</offset>
+            <name>prRes</name>
+            <type>I2</type>
+            <comment>Pseudorange residual</comment>
+            <scale>0.1</scale>
+            <unit>m</unit>
+          </block>
+          <block>
+            <offset>16 + 12*N</offset>
+            <name>flags</name>
+            <type>X4</type>
+            <comment>Bitmask</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:2</index>
+                <type>unsigned value</type>
+                <name>qualityInd</name>
+                <description>Signal quality indicator:
+0: no signal
+1: searching signal
+2: signal acquired
+3: signal detected but unusable
+4: code locked and time synchronized
+5, 6, 7: code and carrier locked and time synchronized
+Note: Since IMES signals are not time synchronized, a channel tracking an IMES signal can never
+reach a quality indicator value of higher than 3.</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>unsigned value</type>
+                <name>svUsed</name>
+                <description>1 = Signal in the subset specified in Signal Identifiers is currently being used for navigation</description>
+              </type>
+              <type>
+                <index>4:5</index>
+                <type>unsigned value</type>
+                <name>health</name>
+                <description>Signal health flag:
+0: unknown
+1: healthy
+2: unhealthy</description>
+              </type>
+              <type>
+                <index>6</index>
+                <type>unsigned value</type>
+                <name>diffCorr</name>
+                <description>1 = differential correction data is available for this SV</description>
+              </type>
+              <type>
+                <index>7</index>
+                <type>unsigned value</type>
+                <name>smoothed</name>
+                <description>1 = carrier smoothed pseudorange used</description>
+              </type>
+              <type>
+                <index>8:10</index>
+                <type>unsigned value</type>
+                <name>orbitSource</name>
+                <description>Orbit source:
+0: no orbit information is available for this SV
+1: ephemeris is used
+2: almanac is used
+3: AssistNow Offline orbit is used
+4: AssistNow Autonomous orbit is used
+5, 6, 7: other orbit information is used</description>
+              </type>
+              <type>
+                <index>11</index>
+                <type>unsigned value</type>
+                <name>ephAvail</name>
+                <description>1 = ephemeris is available for this SV</description>
+              </type>
+              <type>
+                <index>12</index>
+                <type>unsigned value</type>
+                <name>almAvail</name>
+                <description>1 = almanac is available for this SV</description>
+              </type>
+              <type>
+                <index>13</index>
+                <type>unsigned value</type>
+                <name>anoAvail</name>
+                <description>1 = AssistNow Offline data is available for this SV</description>
+              </type>
+              <type>
+                <index>14</index>
+                <type>unsigned value</type>
+                <name>aopAvail</name>
+                <description>1 = AssistNow Autonomous data is available for this SV</description>
+              </type>
+              <type>
+                <index>15</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+              <type>
+                <index>16</index>
+                <type>unsigned value</type>
+                <name>sbasCorrUsed</name>
+                <description>1 = SBAS corrections have been used for a signal in the subset specified in Signal Identifiers</description>
+              </type>
+              <type>
+                <index>17</index>
+                <type>unsigned value</type>
+                <name>rtcmCorrUsed</name>
+                <description>1 = RTCM corrections have been used for a signal in the subset specified in Signal Identifiers</description>
+              </type>
+              <type>
+                <index>18</index>
+                <type>unsigned value</type>
+                <name>slasCorrUsed</name>
+                <description>1 = QZSS SLAS corrections have been used for a signal in the subset specified in Signal Identifiers</description>
+              </type>
+              <type>
+                <index>19</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+              <type>
+                <index>20</index>
+                <type>unsigned value</type>
+                <name>prCorrUsed</name>
+                <description>1 = Pseudorange corrections have been used for a signal in the subset specified in Signal Identifiers</description>
+              </type>
+              <type>
+                <index>21</index>
+                <type>unsigned value</type>
+                <name>crCorrUsed</name>
+                <description>1 = Carrier range corrections have been used for a signal in the subset specified in Signal Identifiers</description>
+              </type>
+              <type>
+                <index>22</index>
+                <type>unsigned value</type>
+                <name>doCorrUsed</name>
+                <description>1 = Range rate (Doppler) corrections have been used for a signal in the subset specified in Signal
+Identifiers</description>
+              </type>
+              <type>
+                <index>23:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-SBAS</name>
+    <type>Periodic/Polled</type>
+    <description>SBAS status data</description>
+    <comment>This message outputs the status of the SBAS sub system</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x32</id>
+      <length>12 + 12*cnt</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>geo</name>
+          <type>U1</type>
+          <comment>PRN Number of the GEO where correction
+and integrity data is used from</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>mode</name>
+          <type>U1</type>
+          <comment>SBAS Mode
+0 Disabled
+1 Enabled integrity
+3 Enabled test mode</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>sys</name>
+          <type>I1</type>
+          <comment>SBAS System (WAAS/EGNOS/...)
+-1 Unknown
+0 WAAS
+1 EGNOS
+2 MSAS
+3 GAGAN
+16 GPS</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>service</name>
+          <type>X1</type>
+          <comment>SBAS Services available</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>Ranging</name>
+              <description>GEO may be used as ranging source</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>Corrections</name>
+              <description>GEO is providing correction data</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>Integrity</name>
+              <description>GEO is providing integrity</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>Testmode</name>
+              <description>GEO is in test mode</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>Bad</name>
+              <description>Problem with signal or broadcast data indicated</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>cnt</name>
+          <type>U1</type>
+          <comment>Number of SV data following</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="cnt" type="repeated">
+          <block>
+            <offset>12 + 12*N</offset>
+            <name>svid</name>
+            <type>U1</type>
+            <comment>SV ID</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>13 + 12*N</offset>
+            <name>flags</name>
+            <type>U1</type>
+            <comment>Flags for this SV</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>14 + 12*N</offset>
+            <name>udre</name>
+            <type>U1</type>
+            <comment>Monitoring status</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>15 + 12*N</offset>
+            <name>svSys</name>
+            <type>U1</type>
+            <comment>System (WAAS/EGNOS/...)
+same as SYS</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>16 + 12*N</offset>
+            <name>svService</name>
+            <type>U1</type>
+            <comment>Services available
+same as SERVICE</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>17 + 12*N</offset>
+            <name>reserved2</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>18 + 12*N</offset>
+            <name>prc</name>
+            <type>I2</type>
+            <comment>Pseudo Range correction in [cm]</comment>
+            <scale>-</scale>
+            <unit>cm</unit>
+          </block>
+          <block>
+            <offset>20 + 12*N</offset>
+            <name>reserved3</name>
+            <type>U1[2]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>22 + 12*N</offset>
+            <name>ic</name>
+            <type>I2</type>
+            <comment>Ionosphere correction in [cm]</comment>
+            <scale>-</scale>
+            <unit>cm</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-SLAS</name>
+    <type>Periodic/Polled</type>
+    <description>QZSS L1S SLAS status data</description>
+    <comment>This message outputs the status of the QZSS L1S SLAS sub system</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 19.2</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x42</id>
+      <length>20 + 8*cnt</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>gmsLon</name>
+          <type>I4</type>
+          <comment>Longitude of the used ground monitoring
+station</comment>
+          <scale>1e-3</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>gmsLat</name>
+          <type>I4</type>
+          <comment>Latitude of the used ground monitoring
+station</comment>
+          <scale>1e-3</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>gmsCode</name>
+          <type>U1</type>
+          <comment>Code of the used ground monitoring
+station according to the QZSS SLAS
+Interface Specification, available from
+qzss.go.jp/en/</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>qzssSvId</name>
+          <type>U1</type>
+          <comment>Satellite identifier of the QZS/GEO whose
+correction data is used (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>serviceFlags</name>
+          <type>X1</type>
+          <comment>Flags regarding SLAS service</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gmsAvailable</name>
+              <description>1 = Ground monitoring station available</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>qzssSvAvailable</name>
+              <description>1 = Correction providing QZSS SV available</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>testMode</name>
+              <description>1 = Currently used QZSS SV in test mode</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>19</offset>
+          <name>cnt</name>
+          <type>U1</type>
+          <comment>Number of pseudorange corrections
+following</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="cnt" type="repeated">
+          <block>
+            <offset>20 + 8*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>GNSS identifier (see Satellite Numbering)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>21 + 8*N</offset>
+            <name>svId</name>
+            <type>U1</type>
+            <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>22 + 8*N</offset>
+            <name>reserved2</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>23 + 8*N</offset>
+            <name>reserved3</name>
+            <type>U1[3]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>26 + 8*N</offset>
+            <name>prc</name>
+            <type>I2</type>
+            <comment>Pseudorange correction</comment>
+            <scale>-</scale>
+            <unit>cm</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-SOL</name>
+    <type>Periodic/Polled</type>
+    <description>Navigation solution information</description>
+    <comment>This message combines position, velocity and time solution in ECEF, including accuracy figures. This message has only been retained for backwards compatibility; users are recommended to use the UBX-NAV-PVT message in preference.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x06</id>
+      <length>52</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>fTOW</name>
+          <type>I4</type>
+          <comment>Fractional part of iTOW (range: +/-
+500000).
+The precise GPS time of week in seconds
+is:
+(iTOW    *  1e-3)    +  (fTOW    *  1e-9)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>week</name>
+          <type>I2</type>
+          <comment>GPS week number of the navigation epoch</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>gpsFix</name>
+          <type>U1</type>
+          <comment>GPSfix Type, range 0..5
+0x00 = No Fix
+0x01 = Dead Reckoning only
+0x02 = 2D-Fix
+0x03 = 3D-Fix
+0x04 = GPS + dead reckoning combined
+0x05 = Time only fix
+0x06..0xff: reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Fix Status Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>GPSfixOK</name>
+              <description>1 = Fix within limits (e.g. DOP &amp; accuracy)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>DiffSoln</name>
+              <description>1 = DGPS used</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>WKNSET</name>
+              <description>1 = Valid GPS week number (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>TOWSET</name>
+              <description>1 = Valid GPS time of week (iTOW &amp; fTOW, see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefX</name>
+          <type>I4</type>
+          <comment>ECEF X coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>ecefY</name>
+          <type>I4</type>
+          <comment>ECEF Y coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>ecefZ</name>
+          <type>I4</type>
+          <comment>ECEF Z coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>pAcc</name>
+          <type>U4</type>
+          <comment>3D Position Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>ecefVX</name>
+          <type>I4</type>
+          <comment>ECEF X velocity</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>ecefVY</name>
+          <type>I4</type>
+          <comment>ECEF Y velocity</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>ecefVZ</name>
+          <type>I4</type>
+          <comment>ECEF Z velocity</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>sAcc</name>
+          <type>U4</type>
+          <comment>Speed Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>pDOP</name>
+          <type>U2</type>
+          <comment>Position DOP</comment>
+          <scale>0.01</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>46</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>47</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Number of SVs used in Nav Solution</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-STATUS</name>
+    <type>Periodic/Polled</type>
+    <description>Receiver navigation status</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x03</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>gpsFix</name>
+          <type>U1</type>
+          <comment>GPSfix Type, this value does not qualify a
+fix as valid and within the limits. See note
+on flag gpsFixOk below.
+0x00 = no fix
+0x01 = dead reckoning only
+0x02 = 2D-fix
+0x03 = 3D-fix
+0x04 = GPS + dead reckoning combined
+0x05 = Time only fix
+0x06..0xff = reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Navigation Status Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>gpsFixOk</name>
+              <description>1 = position and velocity valid and within DOP and ACC Masks.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>diffSoln</name>
+              <description>1 = differential corrections were applied</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>wknSet</name>
+              <description>1 = Week Number valid (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>towSet</name>
+              <description>1 = Time of Week valid (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>fixStat</name>
+          <type>X1</type>
+          <comment>Fix Status Information</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>diffCorr</name>
+              <description>1 = differential corrections available</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>carrSolnValid</name>
+              <description>1 = valid carrSoln</description>
+            </type>
+            <type>
+              <index>2:5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>unsigned value</type>
+              <name>mapMatching</name>
+              <description>map matching status:
+00: none
+01: valid but not used, i.e. map matching data was received, but was too old
+10: valid and used, map matching data was applied
+11: valid and used, map matching data was applied. In case of sensor unavailability map matching
+data enables dead reckoning. This requires map matched latitude/longitude or heading data.</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>flags2</name>
+          <type>X1</type>
+          <comment>further information about navigation
+output</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:1</index>
+              <type>unsigned value</type>
+              <name>psmState</name>
+              <description>power save mode state
+0: ACQUISITION [or when psm disabled]
+1: TRACKING
+2: POWER OPTIMIZED TRACKING
+3: INACTIVE</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>unsigned value</type>
+              <name>spoofDetState</name>
+              <description>Spoofing detection state (not supported in protocol versions less than 18)
+0: Unknown or deactivated
+1: No spoofing indicated
+2: Spoofing indicated
+3: Multiple spoofing indications
+Note that the spoofing state value only reflects the dector state for the current navigation epoch. As
+spoofing can be detected most easily at the transition from real signal to spoofing signal, this is also
+where the detector is triggered the most. I.e. a value of 1 - No spoofing indicated does not mean that
+the receiver is not spoofed, it simply states that the detector was not triggered in this epoch.</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>6:7</index>
+              <type>unsigned value</type>
+              <name>carrSoln</name>
+              <description>Carrier phase range solution status:
+0: no carrier phase range solution
+1: carrier phase range solution with floating ambiguities
+2: carrier phase range solution with fixed ambiguities</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ttff</name>
+          <type>U4</type>
+          <comment>Time to first fix (millisecond time tag)</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>msss</name>
+          <type>U4</type>
+          <comment>Milliseconds since Startup / Reset</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-SVINFO</name>
+    <type>Periodic/Polled</type>
+    <description>Space vehicle information</description>
+    <comment>Information about satellites used or visible This message has only been retained for backwards compatibility; users are recommended to use the UBX-NAV-SAT message in preference.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x30</id>
+      <length>8 + 12*numCh</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>numCh</name>
+          <type>U1</type>
+          <comment>Number of channels</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>globalFlags</name>
+          <type>X1</type>
+          <comment>Bitmask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:2</index>
+              <type>unsigned value</type>
+              <name>chipGen</name>
+              <description>Chip hardware generation
+0: Antaris, Antaris 4
+1: u-blox 5
+2: u-blox 6
+3: u-blox 7
+4: u-blox 8 / u-blox M8</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numCh" type="repeated">
+          <block>
+            <offset>8 + 12*N</offset>
+            <name>chn</name>
+            <type>U1</type>
+            <comment>Channel number, 255 for SVs not
+assigned to a channel</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>9 + 12*N</offset>
+            <name>svid</name>
+            <type>U1</type>
+            <comment>Satellite ID, see Satellite Numbering for
+assignment</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>10 + 12*N</offset>
+            <name>flags</name>
+            <type>X1</type>
+            <comment>Bitmask</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>svUsed</name>
+                <description>SV is used for navigation</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>diffCorr</name>
+                <description>Differential correction data is available for this SV</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>orbitAvail</name>
+                <description>Orbit information is available for this SV (Ephemeris or Almanac)</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>unsigned value</type>
+                <name>orbitEph</name>
+                <description>Orbit information is Ephemeris</description>
+              </type>
+              <type>
+                <index>4</index>
+                <type>unsigned value</type>
+                <name>unhealthy</name>
+                <description>SV is unhealthy / shall not be used</description>
+              </type>
+              <type>
+                <index>5</index>
+                <type>unsigned value</type>
+                <name>orbitAlm</name>
+                <description>Orbit information is Almanac Plus</description>
+              </type>
+              <type>
+                <index>6</index>
+                <type>unsigned value</type>
+                <name>orbitAop</name>
+                <description>Orbit information is AssistNow Autonomous</description>
+              </type>
+              <type>
+                <index>7</index>
+                <type>unsigned value</type>
+                <name>smoothed</name>
+                <description>Carrier smoothed pseudorange used</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>11 + 12*N</offset>
+            <name>quality</name>
+            <type>X1</type>
+            <comment>Bitfield</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>qualityInd</name>
+                <description>Signal Quality indicator (range 0..7). The following list shows the meaning of the different QI values:
+0: no signal
+1: searching signal
+2: signal acquired
+3: signal detected but unusable
+4: code locked and time synchronized
+5, 6, 7: code and carrier locked and time synchronized
+Note: Since IMES signals are not time synchronized, a channel tracking an IMES signal can never
+reach a quality indicator value of higher than 3.</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>12 + 12*N</offset>
+            <name>cno</name>
+            <type>U1</type>
+            <comment>Carrier to Noise Ratio (Signal Strength)</comment>
+            <scale>-</scale>
+            <unit>dBHz</unit>
+          </block>
+          <block>
+            <offset>13 + 12*N</offset>
+            <name>elev</name>
+            <type>I1</type>
+            <comment>Elevation in integer degrees</comment>
+            <scale>-</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>14 + 12*N</offset>
+            <name>azim</name>
+            <type>I2</type>
+            <comment>Azimuth in integer degrees</comment>
+            <scale>-</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>16 + 12*N</offset>
+            <name>prRes</name>
+            <type>I4</type>
+            <comment>Pseudo range residual in centimeters</comment>
+            <scale>-</scale>
+            <unit>cm</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-SVIN</name>
+    <type>Periodic/Polled</type>
+    <description>Survey-in data</description>
+    <comment>This message contains information about survey-in parameters.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20, 20.01, 20.1, 20.2 and 20.3 (only with High Precision GNSS products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x3B</id>
+      <length>40</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>dur</name>
+          <type>U4</type>
+          <comment>Passed survey-in observation time</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>meanX</name>
+          <type>I4</type>
+          <comment>Current survey-in mean position ECEF X
+coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>meanY</name>
+          <type>I4</type>
+          <comment>Current survey-in mean position ECEF Y
+coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>meanZ</name>
+          <type>I4</type>
+          <comment>Current survey-in mean position ECEF Z
+coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>meanXHP</name>
+          <type>I1</type>
+          <comment>Current high-precision survey-in mean
+position ECEF X coordinate. Must be in the
+range -99..+99.
+The current survey-in mean position ECEF
+X coordinate, in units of cm, is given by
+meanX + (0.01 * meanXHP)</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>meanYHP</name>
+          <type>I1</type>
+          <comment>Current high-precision survey-in mean
+position ECEF Y coordinate. Must be in
+the range -99..+99.
+The current survey-in mean position ECEF
+Y coordinate, in units of cm, is given by
+meanY + (0.01 * meanYHP)</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>meanZHP</name>
+          <type>I1</type>
+          <comment>Current high-precision survey-in mean
+position ECEF Z coordinate. Must be in
+the range -99..+99.
+The current survey-in mean position ECEF
+Z coordinate, in units of cm, is given by
+meanZ + (0.01 * meanZHP)</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>27</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>meanAcc</name>
+          <type>U4</type>
+          <comment>Current survey-in mean position accuracy</comment>
+          <scale>-</scale>
+          <unit>0.1_mm</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>obs</name>
+          <type>U4</type>
+          <comment>Number of position observations used
+during survey-in</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>valid</name>
+          <type>U1</type>
+          <comment>Survey-in position validity flag, 1 = valid,
+otherwise 0</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>37</offset>
+          <name>active</name>
+          <type>U1</type>
+          <comment>Survey-in in progress flag, 1 = in-progress,
+otherwise 0</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>38</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-TIMEBDS</name>
+    <type>Periodic/Polled</type>
+    <description>BeiDou time solution</description>
+    <comment>This message reports the precise BDS time of the most recent navigation solution including validity flags and an accuracy estimate.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x24</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>SOW</name>
+          <type>U4</type>
+          <comment>BDS time of week (rounded to seconds)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>fSOW</name>
+          <type>I4</type>
+          <comment>Fractional part of SOW (range: +/-
+500000000).
+The precise BDS time of week in seconds
+is:
+SOW   +  fSOW    *  1e-9</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>week</name>
+          <type>I2</type>
+          <comment>BDS week number of the navigation epoch</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>leapS</name>
+          <type>I1</type>
+          <comment>BDS leap seconds (BDS-UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>sowValid</name>
+              <description>1 = Valid SOW and fSOW (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>weekValid</name>
+              <description>1 = Valid week (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>leapSValid</name>
+              <description>1 = Valid leap second</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-TIMEGAL</name>
+    <type>Periodic/Polled</type>
+    <description>Galileo time solution</description>
+    <comment>This message reports the precise Galileo time of the most recent navigation solution including validity flags and an accuracy estimate.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x25</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>galTow</name>
+          <type>U4</type>
+          <comment>Galileo time of week (rounded to seconds)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>fGalTow</name>
+          <type>I4</type>
+          <comment>Fractional part of the Galileo time of week
+(range: +/-500000000).
+The precise Galileo time of week in
+seconds is:
+galTow     +  fGalTow     *  1e-9</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>galWno</name>
+          <type>I2</type>
+          <comment>Galileo week number</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>leapS</name>
+          <type>I1</type>
+          <comment>Galileo leap seconds (Galileo-UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>galTowValid</name>
+              <description>1 = Valid galTow and fGalTow (see the section Time validity in the Integration manual for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>galWnoValid</name>
+              <description>1 = Valid galWno (see the section Time validity in the Integration manual for details)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>leapSValid</name>
+              <description>1 = Valid leapS</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-TIMEGLO</name>
+    <type>Periodic/Polled</type>
+    <description>GLONASS time solution</description>
+    <comment>This message reports the precise GLO time of the most recent navigation solution including validity flags and an accuracy estimate.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x23</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>TOD</name>
+          <type>U4</type>
+          <comment>GLONASS time of day (rounded to integer
+seconds)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>fTOD</name>
+          <type>I4</type>
+          <comment>Fractional part of TOD (range: +/-
+500000000).
+The precise GLONASS time of day in
+seconds is:
+TOD   +  fTOD    *  1e-9</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>Nt</name>
+          <type>U2</type>
+          <comment>Current date (range: 1-1461), starting at 1
+from the 1st Jan of the year indicated by
+N4 and ending at 1461 at the 31st Dec of
+the third year after that indicated by N4</comment>
+          <scale>-</scale>
+          <unit>days</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>N4</name>
+          <type>U1</type>
+          <comment>Four-year interval number starting from
+1996 (1=1996, 2=2000, 3=2004...)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>todValid</name>
+              <description>1 = Valid TOD and fTOD (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>dateValid</name>
+              <description>1 = Valid N4 and Nt (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-TIMEGPS</name>
+    <type>Periodic/Polled</type>
+    <description>GPS time solution</description>
+    <comment>This message reports the precise GPS time of the most recent navigation solution including validity flags and an accuracy estimate.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x20</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>fTOW</name>
+          <type>I4</type>
+          <comment>Fractional part of iTOW (range: +/-
+500000).
+The precise GPS time of week in seconds
+is:
+(iTOW    *  1e-3)    +  (fTOW    *  1e-9)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>week</name>
+          <type>I2</type>
+          <comment>GPS week number of the navigation epoch</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>leapS</name>
+          <type>I1</type>
+          <comment>GPS leap seconds (GPS-UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>towValid</name>
+              <description>1 = Valid GPS time of week (iTOW &amp; fTOW, (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>weekValid</name>
+              <description>1 = Valid GPS week number (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>leapSValid</name>
+              <description>1 = Valid GPS leap seconds</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time Accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-TIMELS</name>
+    <type>Periodic/Polled</type>
+    <description>Leap second event information</description>
+    <comment>Information about the upcoming leap second event if one is scheduled.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x26</id>
+      <length>24</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>srcOfCurrLs</name>
+          <type>U1</type>
+          <comment>Information source for the current number
+of leap seconds.
+0: Default (hardcoded in the firmware, can
+be outdated)
+1: Derived from time difference between
+GPS and GLONASS time
+2: GPS
+3: SBAS
+4: BeiDou
+5: Galileo
+6: Aided data
+7: Configured
+255: Unknown</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>9</offset>
+          <name>currLs</name>
+          <type>I1</type>
+          <comment>Current number of leap seconds since
+start of GPS time (Jan 6, 1980). It reflects
+how much GPS time is ahead of UTC time.
+Galileo number of leap seconds is the
+same as GPS. BeiDou number of leap
+seconds is 14 less than GPS. GLONASS
+follows UTC time, so no leap seconds.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>srcOfLsChange</name>
+          <type>U1</type>
+          <comment>Information source for the future leap
+second event.
+0: No source
+2: GPS
+3: SBAS
+4: BeiDou
+5: Galileo
+6: GLONASS</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>lsChange</name>
+          <type>I1</type>
+          <comment>Future leap second change if one is
+scheduled. +1 = positive leap second, -1 =
+negative leap second, 0 = no future leap
+second event scheduled or no information
+available.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>timeToLsEvent</name>
+          <type>I4</type>
+          <comment>Number of seconds until the next leap
+second event, or from the last leap second
+event if no future event scheduled. If &gt; 0
+event is in the future, = 0 event is now, &lt; 0
+event is in the past. Valid only if
+validTimeToLsEvent = 1.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>dateOfLsGpsWn</name>
+          <type>U2</type>
+          <comment>GPS week number (WN) of the next leap
+second event or the last one if no future
+event scheduled. Valid only if
+validTimeToLsEvent = 1.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>dateOfLsGpsDn</name>
+          <type>U2</type>
+          <comment>GPS day of week number (DN) for the next
+leap second event or the last one if no
+future event scheduled. Valid only if
+validTimeToLsEvent = 1. (GPS and Galileo
+DN: from 1 = Sun to 7 = Sat. BeiDou DN:
+from 0 = Sun to 6 = Sat.)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>reserved2</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>23</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>validCurrLs</name>
+              <description>1 = Valid current number of leap seconds value.</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>validTimeToLsEvent</name>
+              <description>1 = Valid time to next leap second event or from the last leap second event if no future event scheduled.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-TIMEUTC</name>
+    <type>Periodic/Polled</type>
+    <description>UTC time solution</description>
+    <comment>Note that during a leap second there may be more or less than 60 seconds in a minute. See the description of leap seconds for details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x21</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>tAcc</name>
+          <type>U4</type>
+          <comment>Time accuracy estimate (UTC)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>nano</name>
+          <type>I4</type>
+          <comment>Fraction of second, range -1e9 .. 1e9 (UTC)</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year, range 1999..2099 (UTC)</comment>
+          <scale>-</scale>
+          <unit>y</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month, range 1..12 (UTC)</comment>
+          <scale>-</scale>
+          <unit>month</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day of month, range 1..31 (UTC)</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour of day, range 0..23 (UTC)</comment>
+          <scale>-</scale>
+          <unit>h</unit>
+        </block>
+        <block>
+          <offset>17</offset>
+          <name>min</name>
+          <type>U1</type>
+          <comment>Minute of hour, range 0..59 (UTC)</comment>
+          <scale>-</scale>
+          <unit>min</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>sec</name>
+          <type>U1</type>
+          <comment>Seconds of minute, range 0..60 (UTC)</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>19</offset>
+          <name>valid</name>
+          <type>X1</type>
+          <comment>Validity Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>validTOW</name>
+              <description>1 = Valid Time of Week (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>validWKN</name>
+              <description>1 = Valid Week Number (see Time Validity section for details)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>validUTC</name>
+              <description>1 = Valid UTC Time</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>unsigned value</type>
+              <name>utcStandard</name>
+              <description>UTC standard identifier.
+0: Information not available
+1: Communications Research Labratory (CRL), Tokyo, Japan
+2: National Institute of Standards and Technology (NIST)
+3: U.S. Naval Observatory (USNO)
+4: International Bureau of Weights and Measures (BIPM)
+5: European laboratories
+6: Former Soviet Union (SU)
+7: National Time Service Center (NTSC), China
+15: Unknown</description>
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-VELECEF</name>
+    <type>Periodic/Polled</type>
+    <description>Velocity solution in ECEF</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x11</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>ecefVX</name>
+          <type>I4</type>
+          <comment>ECEF X velocity</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>ecefVY</name>
+          <type>I4</type>
+          <comment>ECEF Y velocity</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>ecefVZ</name>
+          <type>I4</type>
+          <comment>ECEF Z velocity</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>sAcc</name>
+          <type>U4</type>
+          <comment>Speed accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-VELNED</name>
+    <type>Periodic/Polled</type>
+    <description>Velocity solution in NED frame</description>
+    <comment>See important comments concerning validity of position given in section Navigation Output Filters.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x12</id>
+      <length>36</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>velN</name>
+          <type>I4</type>
+          <comment>North velocity component</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>velE</name>
+          <type>I4</type>
+          <comment>East velocity component</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>velD</name>
+          <type>I4</type>
+          <comment>Down velocity component</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>speed</name>
+          <type>U4</type>
+          <comment>Speed (3-D)</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>gSpeed</name>
+          <type>U4</type>
+          <comment>Ground speed (2-D)</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>heading</name>
+          <type>I4</type>
+          <comment>Heading of motion 2-D</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>sAcc</name>
+          <type>U4</type>
+          <comment>Speed accuracy Estimate</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>cAcc</name>
+          <type>U4</type>
+          <comment>Course / Heading accuracy estimate</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-IMES</name>
+    <type>Periodic/Polled</type>
+    <description>Indoor Messaging System information</description>
+    <comment>This message shows the IMES stations the receiver is currently tracking, their data rate, the signal level, the Doppler (with respect to 1575.4282MHz) and what data (without protocol specific overhead) it has received from these stations so far. This message is sent out at the navigation rate the receiver is currently set to. Therefore it allows users to get an overview on the receiver's current state from the IMES perspective.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x61</id>
+      <length>4 + 44*numTx</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>numTx</name>
+          <type>U1</type>
+          <comment>Number of transmitters contained in the
+message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numTx" type="repeated">
+          <block>
+            <offset>4 + 44*N</offset>
+            <name>reserved2</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>5 + 44*N</offset>
+            <name>txId</name>
+            <type>U1</type>
+            <comment>Transmitter identifier</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>6 + 44*N</offset>
+            <name>reserved3</name>
+            <type>U1[3]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>9 + 44*N</offset>
+            <name>cno</name>
+            <type>U1</type>
+            <comment>Carrier to Noise Ratio (Signal Strength)</comment>
+            <scale>-</scale>
+            <unit>dBHz</unit>
+          </block>
+          <block>
+            <offset>10 + 44*N</offset>
+            <name>reserved4</name>
+            <type>U1[2]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>12 + 44*N</offset>
+            <name>doppler</name>
+            <type>I4</type>
+            <comment>Doppler frequency with respect to 1575.
+4282MHz [IIIII.FFF Hz]</comment>
+            <scale>2^-12</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>16 + 44*N</offset>
+            <name>position1_1</name>
+            <type>X4</type>
+            <comment>Position 1 Frame (part 1/2)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:7</index>
+                <type>unsigned value</type>
+                <name>pos1Floor</name>
+                <description>Floor number [1.0 floor resolution] (Offset: -50 floor)</description>
+              </type>
+              <type>
+                <index>8:30</index>
+                <type>signed value</type>
+                <name>pos1Lat</name>
+                <description>Latitude [deg * (180 / 2^23)]</description>
+              </type>
+              <type>
+                <index>31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>20 + 44*N</offset>
+            <name>position1_2</name>
+            <type>X4</type>
+            <comment>Position 1 Frame (part 2/2)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:23</index>
+                <type>signed value</type>
+                <name>pos1Lon</name>
+                <description>Longitude [deg * (360 / 2^24)]</description>
+              </type>
+              <type>
+                <index>24</index>
+                <type>unsigned value</type>
+                <name>pos1Valid</name>
+                <description>Position 1 Frame valid</description>
+              </type>
+              <type>
+                <index>25:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>24 + 44*N</offset>
+            <name>position2_1</name>
+            <type>X4</type>
+            <comment>Position 2 Frame (part 1/3)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:8</index>
+                <type>unsigned value</type>
+                <name>pos2Floor</name>
+                <description>Floor number [0.5 floor resolution] (Offset: -50 floor)</description>
+              </type>
+              <type>
+                <index>9:20</index>
+                <type>unsigned value</type>
+                <name>pos2Alt</name>
+                <description>Altitude [m] (Offset: -95m)</description>
+              </type>
+              <type>
+                <index>21:22</index>
+                <type>unsigned value</type>
+                <name>pos2Acc</name>
+                <description>Accuracy Index (0:undef, 1:&lt;7m, 2:&lt;15m, 3:&gt;15m)</description>
+              </type>
+              <type>
+                <index>23</index>
+                <type>unsigned value</type>
+                <name>pos2Valid</name>
+                <description>Position 2 Frame valid</description>
+              </type>
+              <type>
+                <index>24:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>28 + 44*N</offset>
+            <name>lat</name>
+            <type>I4</type>
+            <comment>Latitude, Position 2 Frame (part 2/3)</comment>
+            <scale>180*2^-24</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>32 + 44*N</offset>
+            <name>lon</name>
+            <type>I4</type>
+            <comment>Longitude, Position 2 Frame (part 3/3)</comment>
+            <scale>360*2^-25</scale>
+            <unit>deg</unit>
+          </block>
+          <block>
+            <offset>36 + 44*N</offset>
+            <name>shortIdFrame</name>
+            <type>X4</type>
+            <comment>Short ID Frame</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:11</index>
+                <type>unsigned value</type>
+                <name>shortId</name>
+                <description>Short ID</description>
+              </type>
+              <type>
+                <index>12</index>
+                <type>unsigned value</type>
+                <name>shortValid</name>
+                <description>Short ID Frame valid</description>
+              </type>
+              <type>
+                <index>13</index>
+                <type>unsigned value</type>
+                <name>shortBoundary</name>
+                <description>Boundary Bit</description>
+              </type>
+              <type>
+                <index>14:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>40 + 44*N</offset>
+            <name>mediumIdLSB</name>
+            <type>U4</type>
+            <comment>Medium ID LSB, Medium ID Frame (part
+1/2)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>44 + 44*N</offset>
+            <name>mediumId_2</name>
+            <type>X4</type>
+            <comment>Medium ID Frame (part 2/2)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>mediumIdMSB</name>
+                <description>Medium ID MSB</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>mediumValid</name>
+                <description>Medium ID Frame valid</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>mediumboundary</name>
+                <description>Boundary Bit</description>
+              </type>
+              <type>
+                <index>3:31</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-MEASX</name>
+    <type>Periodic/Polled</type>
+    <description>Satellite measurements for RRLP</description>
+    <comment>The message payload data is, where possible and appropriate, according to the Radio Resource LCS (Location Services) Protocol (RRLP) [1]. One exception is the satellite and GNSS IDs, which here are given according to the Satellite Numbering scheme. The correct satellites have to be selected and their satellite ID translated accordingly [1, tab. A.10.14] for use in a RRLP Measure Position Response Component. Similarly, the measurement reference time of week has to be forwarded correctly (modulo 14400000 for the 24 LSB GPS measurements variant, modulo 3600000 for the 22 LSB Galileo and Additional Navigation Satelllite Systems (GANSS) measurements variant) of the RRLP measure position response to the SMLC. Reference: [1] ETSI TS 144 031 V11.0.0 (2012-10), Digital cellular telecommunications system (Phase 2+), Location Services (LCS), Mobile Station (MS) - Serving Mobile Location Centre (SMLC), Radio Resource LCS Protocol (RRLP), (3GPP TS 44.031 version 11.0.0 Release 11).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x14</id>
+      <length>44 + 24*numSV</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version, currently 0x01</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>gpsTOW</name>
+          <type>U4</type>
+          <comment>GPS measurement reference time</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>gloTOW</name>
+          <type>U4</type>
+          <comment>GLONASS measurement reference time</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>bdsTOW</name>
+          <type>U4</type>
+          <comment>BeiDou measurement reference time</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>qzssTOW</name>
+          <type>U4</type>
+          <comment>QZSS measurement reference time</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>gpsTOWacc</name>
+          <type>U2</type>
+          <comment>GPS measurement reference time
+accuracy (0xffff = &gt; 4s)</comment>
+          <scale>2^-4</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>gloTOWacc</name>
+          <type>U2</type>
+          <comment>GLONASS measurement reference time
+accuracy (0xffff = &gt; 4s)</comment>
+          <scale>2^-4</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>bdsTOWacc</name>
+          <type>U2</type>
+          <comment>BeiDou measurement reference time
+accuracy (0xffff = &gt; 4s)</comment>
+          <scale>2^-4</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>30</offset>
+          <name>reserved3</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>qzssTOWacc</name>
+          <type>U2</type>
+          <comment>QZSS measurement reference time
+accuracy (0xffff = &gt; 4s)</comment>
+          <scale>2^-4</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>34</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Number of satellites in repeated block</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>35</offset>
+          <name>flags</name>
+          <type>U1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:1</index>
+              <type>unsigned value</type>
+              <name>towSet</name>
+              <description>TOW set (0 = no, 1 or 2 = yes)</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>reserved4</name>
+          <type>U1[8]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSV" type="repeated">
+          <block>
+            <offset>44 + 24*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>GNSS ID (see Satellite Numbering)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>45 + 24*N</offset>
+            <name>svId</name>
+            <type>U1</type>
+            <comment>Satellite ID (see Satellite Numbering)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>46 + 24*N</offset>
+            <name>cNo</name>
+            <type>U1</type>
+            <comment>carrier noise ratio (0..63)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>47 + 24*N</offset>
+            <name>mpathIndic</name>
+            <type>U1</type>
+            <comment>multipath index (according to [1]) (0 = not
+measured, 1 = low, 2 = medium, 3 = high)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>48 + 24*N</offset>
+            <name>dopplerMS</name>
+            <type>I4</type>
+            <comment>Doppler measurement</comment>
+            <scale>0.04</scale>
+            <unit>m/s</unit>
+          </block>
+          <block>
+            <offset>52 + 24*N</offset>
+            <name>dopplerHz</name>
+            <type>I4</type>
+            <comment>Doppler measurement</comment>
+            <scale>0.2</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>56 + 24*N</offset>
+            <name>wholeChips</name>
+            <type>U2</type>
+            <comment>whole value of the code phase
+measurement (0..1022 for GPS)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>58 + 24*N</offset>
+            <name>fracChips</name>
+            <type>U2</type>
+            <comment>fractional value of the code phase
+measurement (0..1023)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>60 + 24*N</offset>
+            <name>codePhase</name>
+            <type>U4</type>
+            <comment>Code phase</comment>
+            <scale>2^-21</scale>
+            <unit>ms</unit>
+          </block>
+          <block>
+            <offset>64 + 24*N</offset>
+            <name>intCodePhase</name>
+            <type>U1</type>
+            <comment>Integer (part of the) code phase</comment>
+            <scale>-</scale>
+            <unit>ms</unit>
+          </block>
+          <block>
+            <offset>65 + 24*N</offset>
+            <name>pseuRangeRMSErr</name>
+            <type>U1</type>
+            <comment>pseudorange RMS error index (according
+to [1]) (0..63)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>66 + 24*N</offset>
+            <name>reserved5</name>
+            <type>U1[2]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-PMREQ</name>
+    <type>Command</type>
+    <description>Power management request</description>
+    <comment>This message requests a power management related task of the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x41</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>duration</name>
+          <type>U4</type>
+          <comment>Duration of the requested task, set to zero
+for infinite duration. The maximum
+supported time is 12 days.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>task flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>backup</name>
+              <description>The receiver goes into backup mode for a time period defined by duration, provided that it is not
+connected to USB</description>
+            </type>
+            <type>
+              <index>2:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-PMREQ</name>
+    <type>Command</type>
+    <description>Power management request</description>
+    <comment>This message requests a power management related task of the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x41</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>duration</name>
+          <type>U4</type>
+          <comment>Duration of the requested task, set to zero
+for infinite duration. The maximum
+supported time is 12 days.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>task flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>backup</name>
+              <description>The receiver goes into backup mode for a time period defined by duration, provided that it is not
+connected to USB</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>force</name>
+              <description>Force receiver backup while USB is connected. USB interface will be disabled.</description>
+            </type>
+            <type>
+              <index>3:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>wakeupSources</name>
+          <type>X4</type>
+          <comment>Configure pins to wake up the receiver.
+The receiver wakes up if there is either a
+falling or a rising edge on one of the
+configured pins.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:2</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>uartrx</name>
+              <description>Wake up the receiver if there is an edge on the UART RX pin</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>extint0</name>
+              <description>Wake up the receiver if there is an edge on the EXTINT0 pin</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>extint1</name>
+              <description>Wake up the receiver if there is an edge on the EXTINT1 pin</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>spics</name>
+              <description>Wake up the receiver if there is an edge on the SPI CS pin</description>
+            </type>
+            <type>
+              <index>8:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-RAWX</name>
+    <type>Periodic/Polled</type>
+    <description>Multi-GNSS raw measurement data</description>
+    <comment>This message contains the information needed to be able to generate a RINEX 3 multi-GNSS observation file (see ftp://ftp.igs.org/pub/data/format/). This message contains pseudorange, Doppler, carrier phase, phase lock and signal quality information for GNSS satellites once signals have been synchronized. This message supports all active GNSS.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 17 (only with Time Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x15</id>
+      <length>16 + 32*numMeas</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>rcvTow</name>
+          <type>R8</type>
+          <comment>Measurement time of week in receiver
+local time approximately aligned to the
+GPS time system. The receiver local time
+of week, week number and leap second
+information can be used to translate the
+time to other time systems. More
+information about the difference in time
+systems can be found in the RINEX 3
+format documentation. For a receiver
+operating in GLONASS only mode, UTC
+time can be determined by subtracting
+the leapS field from GPS time regardless
+of whether the GPS leap seconds are valid.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>week</name>
+          <type>U2</type>
+          <comment>GPS week number in receiver local time.</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>leapS</name>
+          <type>I1</type>
+          <comment>GPS leap seconds (GPS-UTC). This field
+represents the receiver's best knowledge
+of the leap seconds offset. A flag is given
+in the recStat bitfield to indicate if the
+leap seconds are known.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>numMeas</name>
+          <type>U1</type>
+          <comment>Number of measurements to follow</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>recStat</name>
+          <type>X1</type>
+          <comment>Receiver tracking status bitfield</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>leapSec</name>
+              <description>Leap seconds have been determined</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>clkReset</name>
+              <description>Clock reset applied. Typically the receiver clock is changed in increments of integer milliseconds.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numMeas" type="repeated">
+          <block>
+            <offset>16 + 32*N</offset>
+            <name>prMes</name>
+            <type>R8</type>
+            <comment>Pseudorange measurement [m].
+GLONASS inter frequency channel delays
+are compensated with an internal
+calibration table.</comment>
+            <scale>-</scale>
+            <unit>m</unit>
+          </block>
+          <block>
+            <offset>24 + 32*N</offset>
+            <name>cpMes</name>
+            <type>R8</type>
+            <comment>Carrier phase measurement [cycles]. The
+carrier phase initial ambiguity is initialized
+using an approximate value to make the
+magnitude of the phase close to the
+pseudorange measurement. Clock resets
+are applied to both phase and code
+measurements in accordance with the
+RINEX specification.</comment>
+            <scale>-</scale>
+            <unit>cycles</unit>
+          </block>
+          <block>
+            <offset>32 + 32*N</offset>
+            <name>doMes</name>
+            <type>R4</type>
+            <comment>Doppler measurement (positive sign for
+approaching satellites) [Hz]</comment>
+            <scale>-</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>36 + 32*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>GNSS identifier (see Satellite Numbering
+for a list of identifiers)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>37 + 32*N</offset>
+            <name>svId</name>
+            <type>U1</type>
+            <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>38 + 32*N</offset>
+            <name>reserved2</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>39 + 32*N</offset>
+            <name>freqId</name>
+            <type>U1</type>
+            <comment>Only used for GLONASS: This is the
+frequency slot + 7 (range from 0 to 13)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>40 + 32*N</offset>
+            <name>locktime</name>
+            <type>U2</type>
+            <comment>Carrier phase locktime counter (maximum
+64500ms)</comment>
+            <scale>-</scale>
+            <unit>ms</unit>
+          </block>
+          <block>
+            <offset>42 + 32*N</offset>
+            <name>cno</name>
+            <type>U1</type>
+            <comment>Carrier-to-noise density ratio (signal
+strength) [dB-Hz]</comment>
+            <scale>-</scale>
+            <unit>dBHz</unit>
+          </block>
+          <block>
+            <offset>43 + 32*N</offset>
+            <name>prStdev</name>
+            <type>X1</type>
+            <comment>Estimated pseudorange measurement
+standard deviation</comment>
+            <scale>0.01*2^n</scale>
+            <unit>m</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>prStd</name>
+                <description>Estimated pseudorange standard deviation</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>44 + 32*N</offset>
+            <name>cpStdev</name>
+            <type>X1</type>
+            <comment>Estimated carrier phase measurement
+standard deviation (note a raw value of
+0x0F indicates the value is invalid)</comment>
+            <scale>0.004</scale>
+            <unit>cycles</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>cpStd</name>
+                <description>Estimated carrier phase standard deviation</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>45 + 32*N</offset>
+            <name>doStdev</name>
+            <type>X1</type>
+            <comment>Estimated Doppler measurement
+standard deviation.</comment>
+            <scale>0.002*2^n</scale>
+            <unit>Hz</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>doStd</name>
+                <description>Estimated Doppler standard deviation</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>46 + 32*N</offset>
+            <name>trkStat</name>
+            <type>X1</type>
+            <comment>Tracking status bitfield (see graphic below
+)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>prValid</name>
+                <description>Pseudorange valid</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>cpValid</name>
+                <description>Carrier phase valid</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>halfCyc</name>
+                <description>Half cycle valid</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>unsigned value</type>
+                <name>subHalfCyc</name>
+                <description>Half cycle subtracted from phase</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>47 + 32*N</offset>
+            <name>reserved3</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-RAWX</name>
+    <type>Periodic/Polled</type>
+    <description>Multi-GNSS raw measurements</description>
+    <comment>This message contains the information needed to be able to generate a RINEX 3 multi-GNSS observation file (see ftp://ftp.igs.org/pub/data/format/). This message contains pseudorange, Doppler, carrier phase, phase lock and signal quality information for GNSS satellites once signals have been synchronized. This message supports all active GNSS. The only difference between this version of the message and the previous version (UBX-RXM-RAWX-DATA0) is the addition of the version field.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or High Precision GNSS or Time Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x15</id>
+      <length>16 + 32*numMeas</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>rcvTow</name>
+          <type>R8</type>
+          <comment>Measurement time of week in receiver
+local time approximately aligned to the
+GPS time system.
+The receiver local time of week, week
+number and leap second information can
+be used to translate the time to other time
+systems. More information about the
+difference in time systems can be found in
+the RINEX 3 format documentation. For a
+receiver operating in GLONASS only mode,
+UTC time can be determined by
+subtracting the leapS field from GPS time
+regardless of whether the GPS leap
+seconds are valid.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>week</name>
+          <type>U2</type>
+          <comment>GPS week number in receiver local time.</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>leapS</name>
+          <type>I1</type>
+          <comment>GPS leap seconds (GPS-UTC). This field
+represents the receiver's best knowledge
+of the leap seconds offset. A flag is given
+in the recStat bitfield to indicate if the
+leap seconds are known.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>numMeas</name>
+          <type>U1</type>
+          <comment>Number of measurements to follow</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>recStat</name>
+          <type>X1</type>
+          <comment>Receiver tracking status bitfield</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>leapSec</name>
+              <description>Leap seconds have been determined</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>clkReset</name>
+              <description>Clock reset applied. Typically the receiver clock is changed in increments of integer milliseconds.</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numMeas" type="repeated">
+          <block>
+            <offset>16 + 32*N</offset>
+            <name>prMes</name>
+            <type>R8</type>
+            <comment>Pseudorange measurement [m].
+GLONASS inter frequency channel delays
+are compensated with an internal
+calibration table.</comment>
+            <scale>-</scale>
+            <unit>m</unit>
+          </block>
+          <block>
+            <offset>24 + 32*N</offset>
+            <name>cpMes</name>
+            <type>R8</type>
+            <comment>Carrier phase measurement [cycles]. The
+carrier phase initial ambiguity is initialized
+using an approximate value to make the
+magnitude of the phase close to the
+pseudorange measurement. Clock resets
+are applied to both phase and code
+measurements in accordance with the
+RINEX specification.</comment>
+            <scale>-</scale>
+            <unit>cycles</unit>
+          </block>
+          <block>
+            <offset>32 + 32*N</offset>
+            <name>doMes</name>
+            <type>R4</type>
+            <comment>Doppler measurement (positive sign for
+approaching satellites) [Hz]</comment>
+            <scale>-</scale>
+            <unit>Hz</unit>
+          </block>
+          <block>
+            <offset>36 + 32*N</offset>
+            <name>gnssId</name>
+            <type>U1</type>
+            <comment>GNSS identifier (see Satellite Numbering
+for a list of identifiers)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>37 + 32*N</offset>
+            <name>svId</name>
+            <type>U1</type>
+            <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>38 + 32*N</offset>
+            <name>sigId</name>
+            <type>U1</type>
+            <comment>New style signal identifier (see Signal
+Identifiers).(not supported in protocol
+versions less than 27)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>39 + 32*N</offset>
+            <name>freqId</name>
+            <type>U1</type>
+            <comment>Only used for GLONASS: This is the
+frequency slot + 7 (range from 0 to 13)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>40 + 32*N</offset>
+            <name>locktime</name>
+            <type>U2</type>
+            <comment>Carrier phase locktime counter (maximum
+64500ms)</comment>
+            <scale>-</scale>
+            <unit>ms</unit>
+          </block>
+          <block>
+            <offset>42 + 32*N</offset>
+            <name>cno</name>
+            <type>U1</type>
+            <comment>Carrier-to-noise density ratio (signal
+strength) [dB-Hz]</comment>
+            <scale>-</scale>
+            <unit>dBHz</unit>
+          </block>
+          <block>
+            <offset>43 + 32*N</offset>
+            <name>prStdev</name>
+            <type>X1</type>
+            <comment>Estimated pseudorange measurement
+standard deviation</comment>
+            <scale>0.01*2^n</scale>
+            <unit>m</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>prStd</name>
+                <description>Estimated pseudorange standard deviation</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>44 + 32*N</offset>
+            <name>cpStdev</name>
+            <type>X1</type>
+            <comment>Estimated carrier phase measurement
+standard deviation (note a raw value of
+0x0F indicates the value is invalid)</comment>
+            <scale>0.004</scale>
+            <unit>cycles</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>cpStd</name>
+                <description>Estimated carrier phase standard deviation</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>45 + 32*N</offset>
+            <name>doStdev</name>
+            <type>X1</type>
+            <comment>Estimated Doppler measurement
+standard deviation.</comment>
+            <scale>0.002*2^n</scale>
+            <unit>Hz</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>doStd</name>
+                <description>Estimated Doppler standard deviation</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>46 + 32*N</offset>
+            <name>trkStat</name>
+            <type>X1</type>
+            <comment>Tracking status bitfield (see graphic below
+)</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>prValid</name>
+                <description>Pseudorange valid</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>cpValid</name>
+                <description>Carrier phase valid</description>
+              </type>
+              <type>
+                <index>2</index>
+                <type>unsigned value</type>
+                <name>halfCyc</name>
+                <description>Half cycle valid</description>
+              </type>
+              <type>
+                <index>3</index>
+                <type>unsigned value</type>
+                <name>subHalfCyc</name>
+                <description>Half cycle subtracted from phase</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>47 + 32*N</offset>
+            <name>reserved2</name>
+            <type>U1</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-RLM</name>
+    <type>Output</type>
+    <description>Galileo SAR short-RLM report</description>
+    <comment>This message contains the contents of any Galileo Search and Rescue (SAR) Short Return Link Message detected by the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x59</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x01 for Short-RLM)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Identifier of transmitting satellite (see
+Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>beacon</name>
+          <type>U1[8]</type>
+          <comment>Beacon identifier (60 bits), with bytes
+ordered by earliest transmitted (most
+significant) first. Top four bits of first byte
+are zero.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>message</name>
+          <type>U1</type>
+          <comment>Message code (4 bits)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>params</name>
+          <type>U1[2]</type>
+          <comment>Parameters (16 bits), with bytes ordered
+by earliest transmitted (most significant)
+first.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-RLM</name>
+    <type>Output</type>
+    <description>Galileo SAR long-RLM report</description>
+    <comment>This message contains the contents of any Galileo Search and Rescue (SAR) Long Return Link Message detected by the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x59</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0x02 for Long-RLM)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Identifier of transmitting satellite (see
+Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>beacon</name>
+          <type>U1[8]</type>
+          <comment>Beacon identifier (60 bits), with bytes
+ordered by earliest transmitted (most
+significant) first. Top four bits of first byte
+are zero.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>message</name>
+          <type>U1</type>
+          <comment>Message code (4 bits)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>params</name>
+          <type>U1[12]</type>
+          <comment>Parameters (96 bits), with bytes ordered
+by earliest transmitted (most significant)
+first.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>reserved2</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-RTCM</name>
+    <type>Output</type>
+    <description>RTCM input status</description>
+    <comment>This message shows info on a received RTCM input message. It is output upon successful parsing of an RTCM input message, irrespective of whether the RTCM message is supported or not by the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2 and 20.3</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x32</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x02 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>RTCM input status flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>crcFailed</name>
+              <description>0 when RTCM message received and passed CRC check, 1 when failed, in which case refStation and
+msgType might be corrupted and misleading</description>
+            </type>
+            <type>
+              <index>1:2</index>
+              <type>unsigned value</type>
+              <name>msgUsed</name>
+              <description>2 = RTCM message used successfully by the receiver, 1 = not used, 0 = do not know</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>subType</name>
+          <type>U2</type>
+          <comment>Message subtype, only applicable to u-
+blox proprietary RTCM message 4072 (not
+available on all products)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>refStation</name>
+          <type>U2</type>
+          <comment>Reference station ID:
+For RTCM 2.3: Reference station ID of the
+received RTCM 2 input message. Valid
+range 0-1023.
+For RTCM 3.3: Reference station ID
+(DF003) of the received RTCM input
+message. Valid range 0-4095. Reported
+only for the standard RTCM messages
+that include the DF003 field and for the u-
+blox proprietary RTCM messages 4072.x.
+For all other messages, reports 0xFFFF.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>msgType</name>
+          <type>U2</type>
+          <comment>Message type</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-SFRBX</name>
+    <type>Output</type>
+    <description>Broadcast navigation data subframe</description>
+    <comment>This message reports a complete subframe of broadcast navigation data decoded from a single signal. The number of data words reported in each message depends on the nature of the signal. See the section on Broadcast Navigation Data for further details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 17 (only with Time Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x13</id>
+      <length>8 + 4*numWords</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>gnssId</name>
+          <type>U1</type>
+          <comment>GNSS identifier (see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>freqId</name>
+          <type>U1</type>
+          <comment>Only used for GLONASS: This is the
+frequency slot + 7 (range from 0 to 13)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>numWords</name>
+          <type>U1</type>
+          <comment>The number of data words contained in
+this message (0..16)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved3</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numWords" type="repeated">
+          <block>
+            <offset>8 + 4*N</offset>
+            <name>dwrd</name>
+            <type>U4</type>
+            <comment>The data words</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-SFRBX</name>
+    <type>Output</type>
+    <description>Broadcast navigation data subframe</description>
+    <comment>This message reports a complete subframe of broadcast navigation data decoded from a single signal. The number of data words reported in each message depends on the nature of the signal. See the section on Broadcast Navigation Data for further details.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x13</id>
+      <length>8 + 4*numWords</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>gnssId</name>
+          <type>U1</type>
+          <comment>GNSS identifier (see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>svId</name>
+          <type>U1</type>
+          <comment>Satellite identifier (see Satellite
+Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>freqId</name>
+          <type>U1</type>
+          <comment>Only used for GLONASS: This is the
+frequency slot + 7 (range from 0 to 13)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>numWords</name>
+          <type>U1</type>
+          <comment>The number of data words contained in
+this message (up to 10, for currently
+supported signals)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>chn</name>
+          <type>U1</type>
+          <comment>The tracking channel number the
+message was received on</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version, (0x02 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved2</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numWords" type="repeated">
+          <block>
+            <offset>8 + 4*N</offset>
+            <name>dwrd</name>
+            <type>U4</type>
+            <comment>The data words</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-RXM-SVSI</name>
+    <type>Periodic/Polled</type>
+    <description>SV status info</description>
+    <comment>Status of the receiver manager knowledge about GPS Orbit Validity This message has only been retained for backwards compatibility; users are recommended to use the UBX-NAV-ORB message in preference.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x02</class>
+      <id>0x20</id>
+      <length>8 + 6*numSV</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>week</name>
+          <type>I2</type>
+          <comment>GPS week number of the navigation epoch</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>numVis</name>
+          <type>U1</type>
+          <comment>Number of visible satellites</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>numSV</name>
+          <type>U1</type>
+          <comment>Number of per-SV data blocks following</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSV" type="repeated">
+          <block>
+            <offset>8 + 6*N</offset>
+            <name>svid</name>
+            <type>U1</type>
+            <comment>Satellite ID</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>9 + 6*N</offset>
+            <name>svFlag</name>
+            <type>X1</type>
+            <comment>Information Flags</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>ura</name>
+                <description>Figure of Merit (URA) range 0..15</description>
+              </type>
+              <type>
+                <index>4</index>
+                <type>unsigned value</type>
+                <name>healthy</name>
+                <description>SV healthy flag</description>
+              </type>
+              <type>
+                <index>5</index>
+                <type>unsigned value</type>
+                <name>ephVal</name>
+                <description>Ephemeris valid</description>
+              </type>
+              <type>
+                <index>6</index>
+                <type>unsigned value</type>
+                <name>almVal</name>
+                <description>Almanac valid</description>
+              </type>
+              <type>
+                <index>7</index>
+                <type>unsigned value</type>
+                <name>notAvail</name>
+                <description>SV not available</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>10 + 6*N</offset>
+            <name>azim</name>
+            <type>I2</type>
+            <comment>Azimuth</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>12 + 6*N</offset>
+            <name>elev</name>
+            <type>I1</type>
+            <comment>Elevation</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>13 + 6*N</offset>
+            <name>age</name>
+            <type>X1</type>
+            <comment>Age of Almanac and Ephemeris:</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>almAge</name>
+                <description>Age of ALM in days offset by 4
+i.e. the reference time may be in the future:
+ageOfAlm = (age &amp; 0x0f) - 4</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>unsigned value</type>
+                <name>ephAge</name>
+                <description>Age of EPH in hours offset by 4.
+i.e. the reference time may be in the future:
+ageOfEph = ((age &amp; 0xf0) &gt;&gt; 4) - 4</description>
+              </type>
+            </bitfield>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-SEC-UNIQID</name>
+    <type>Output</type>
+    <description>Unique chip ID</description>
+    <comment>This message is used to retrieve a unique chip identifier (40 bits, 5 bytes).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x27</class>
+      <id>0x03</id>
+      <length>9</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>uniqueId</name>
+          <type>U1[5]</type>
+          <comment>Unique chip ID</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-DOSC</name>
+    <type>Output</type>
+    <description>Disciplined oscillator control</description>
+    <comment>The receiver sends this message when it is disciplining an external oscillator and the external oscillator is set up to be controlled via the host.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x11</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>value</name>
+          <type>U4</type>
+          <comment>The raw value to be applied to the DAC
+controlling the external oscillator. The
+least significant bits should be written to
+the DAC, with the higher bits being
+ignored.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-FCHG</name>
+    <type>Periodic/Polled</type>
+    <description>Oscillator frequency changed notification</description>
+    <comment>This message reports frequency changes commanded by the sync manager for the internal and external oscillator. It is output at the configured rate even if the sync manager decides not to command a frequency change.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x16</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch
+from which the sync manager obtains the
+GNSS specific data.
+Like for the NAV message, the iTOW can
+be used to group messages of a single
+sync manager run together (See the
+description of iTOW for details)</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>intDeltaFreq</name>
+          <type>I4</type>
+          <comment>Frequency increment of the internal
+oscillator</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>intDeltaFreqUnc</name>
+          <type>U4</type>
+          <comment>Uncertainty of the internal oscillator
+frequency increment</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>intRaw</name>
+          <type>U4</type>
+          <comment>Current raw DAC setting commanded to
+the internal oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>extDeltaFreq</name>
+          <type>I4</type>
+          <comment>Frequency increment of the external
+oscillator</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>extDeltaFreqUnc</name>
+          <type>U4</type>
+          <comment>Uncertainty of the external oscillator
+frequency increment</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>extRaw</name>
+          <type>U4</type>
+          <comment>Current raw DAC setting commanded to
+the external oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-HOC</name>
+    <type>Input</type>
+    <description>Host oscillator control</description>
+    <comment>This message can be sent by the host to force the receiver to bypass the disciplining algorithms in the SMGR and carry out the instructed changes to internal or external oscillator frequency. No checks are carried out on the size of the frequency change requested, so normal limits imposed by the SMGR are ignored. It is recommended that the disciplining of that oscillator is disabled before this message is sent (i.e. by clearing the enableInternal or enableExternal flag in the UBX-CFG-SMGR message), otherwise the autonomous disciplining processes may cancel the effect of the direct command. Note that the GNSS subsystem may temporarily lose track of some/all satellite signals if a large change of the internal oscillator is made.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x17</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>oscId</name>
+          <type>U1</type>
+          <comment>Id of oscillator:
+0: internal oscillator
+1: external oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>flags</name>
+          <type>U1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>raw</name>
+              <description>Type of value:
+0: frequency offset
+1: raw digital output</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>difference</name>
+              <description>Nature of value:
+0: absolute (i.e. relative to 0)
+1: relative to current setting</description>
+            </type>
+            <type>
+              <index>2:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>value</name>
+          <type>I4</type>
+          <comment>Required frequency offset or raw output,
+depending on the flags</comment>
+          <scale>2^-8</scale>
+          <unit>ppb/-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-SMEAS</name>
+    <type>Input/Output</type>
+    <description>Source measurement</description>
+    <comment>Frequency and/or phase measurement of synchronization sources. The measurements are relative to the nominal frequency and nominal phase. The receiver reports the measurements on its sync sources using this message. Which measurements are reported can be configured using UBX-CFG-SMGR. The host may report offset of the receiver's outputs with this message as well. The receiver has to be configured using UBX-CFG-SMGR to enable the use of the external measurement messages. Otherwise the receiver will ignore them.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x13</id>
+      <length>12 + 24*numMeas</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>numMeas</name>
+          <type>U1</type>
+          <comment>Number of measurements in repeated
+block</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>Time of the week</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numMeas" type="repeated">
+          <block>
+            <offset>12 + 24*N</offset>
+            <name>sourceId</name>
+            <type>U1</type>
+            <comment>Index of source. SMEAS can provide six
+measurement sources. The first four
+sourceId values represent measurements
+made by the receiver and sent to the host.
+The first of these with a sourceId value of
+0 is a measurement of the internal
+oscillator against the current receiver
+time-and-frequency estimate. The
+internal oscillator is being disciplined
+against that estimate and this result
+represents the current offset between the
+actual and desired internal oscillator
+states. The next three sourceId values
+represent frequency and time
+measurements made by the receiver
+against the internal oscillator. sourceId 1
+represents the GNSS-derived frequency
+and time compared with the internal
+oscillator frequency and time. sourceId2
+give measurements of a signal coming in
+on EXTINT0. sourceId 3 corresponds to a
+similar measurement on EXTINT1. The
+remaining two of these measurements
+(sourceId 4 and 5) are made by the host
+and sent to the receiver. A measurement
+with sourceId 4 is a measurement by the
+host of the internal oscillator and sourceId
+5 indicates a host measurement of the
+external oscillator.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>13 + 24*N</offset>
+            <name>flags</name>
+            <type>X1</type>
+            <comment>Flags</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0</index>
+                <type>unsigned value</type>
+                <name>freqValid</name>
+                <description>1 = frequency measurement is valid</description>
+              </type>
+              <type>
+                <index>1</index>
+                <type>unsigned value</type>
+                <name>phaseValid</name>
+                <description>1 = phase measurement is valid</description>
+              </type>
+              <type>
+                <index>2:7</index>
+                <type>reserved</type>
+                <name />
+                <description />
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>14 + 24*N</offset>
+            <name>phaseOffsetFrac</name>
+            <type>I1</type>
+            <comment>Sub-nanosecond phase offset; the total
+offset is the sum of phaseOffset and
+phaseOffsetFrac</comment>
+            <scale>2^-8</scale>
+            <unit>ns</unit>
+          </block>
+          <block>
+            <offset>15 + 24*N</offset>
+            <name>phaseUncFrac</name>
+            <type>U1</type>
+            <comment>Sub-nanosecond phase uncertainty</comment>
+            <scale>2^-8</scale>
+            <unit>ns</unit>
+          </block>
+          <block>
+            <offset>16 + 24*N</offset>
+            <name>phaseOffset</name>
+            <type>I4</type>
+            <comment>Phase offset, positive if the source lags
+accurate phase and negative if the source
+is early</comment>
+            <scale>-</scale>
+            <unit>ns</unit>
+          </block>
+          <block>
+            <offset>20 + 24*N</offset>
+            <name>phaseUnc</name>
+            <type>U4</type>
+            <comment>Phase uncertainty (one standard
+deviation)</comment>
+            <scale>-</scale>
+            <unit>ns</unit>
+          </block>
+          <block>
+            <offset>24 + 24*N</offset>
+            <name>reserved3</name>
+            <type>U1[4]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>28 + 24*N</offset>
+            <name>freqOffset</name>
+            <type>I4</type>
+            <comment>Frequency offset, positive if the source
+frequency is too high, negative if the
+frequency is too low.</comment>
+            <scale>2^-8</scale>
+            <unit>ppb</unit>
+          </block>
+          <block>
+            <offset>32 + 24*N</offset>
+            <name>freqUnc</name>
+            <type>U4</type>
+            <comment>Frequency uncertainty (one standard
+deviation)</comment>
+            <scale>2^-8</scale>
+            <unit>ppb</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-SVIN</name>
+    <type>Periodic/Polled</type>
+    <description>Survey-in data</description>
+    <comment>This message contains information about survey-in parameters. For details about the Time mode see section Time mode configuration.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync or Time Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x04</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>dur</name>
+          <type>U4</type>
+          <comment>Passed survey-in observation time</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>meanX</name>
+          <type>I4</type>
+          <comment>Current survey-in mean position ECEF X
+coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>meanY</name>
+          <type>I4</type>
+          <comment>Current survey-in mean position ECEF Y
+coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>meanZ</name>
+          <type>I4</type>
+          <comment>Current survey-in mean position ECEF Z
+coordinate</comment>
+          <scale>-</scale>
+          <unit>cm</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>meanV</name>
+          <type>U4</type>
+          <comment>Current survey-in mean position 3D
+variance</comment>
+          <scale>-</scale>
+          <unit>mm^2</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>obs</name>
+          <type>U4</type>
+          <comment>Number of position observations used
+during survey-in</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>valid</name>
+          <type>U1</type>
+          <comment>Survey-in position validity flag, 1 = valid,
+otherwise 0</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>25</offset>
+          <name>active</name>
+          <type>U1</type>
+          <comment>Survey-in in progress flag, 1 = in-progress,
+otherwise 0</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>26</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-TM2</name>
+    <type>Periodic/Polled</type>
+    <description>Time mark data</description>
+    <comment>This message contains information for high precision time stamping / pulse counting. The delay figures and timebase given in UBX-CFG-TP5 are also applied to the time results output in this message.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x03</id>
+      <length>28</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>ch</name>
+          <type>U1</type>
+          <comment>Channel (i.e. EXTINT) upon which the
+pulse was measured</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Bitmask</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>mode</name>
+              <description>0=single
+1=running</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>run</name>
+              <description>0=armed
+1=stopped</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>newFallingEdge</name>
+              <description>New falling edge detected</description>
+            </type>
+            <type>
+              <index>3:4</index>
+              <type>unsigned value</type>
+              <name>timeBase</name>
+              <description>0=Time base is Receiver time
+1=Time base is GNSS time (the system according to the configuration in UBX-CFG-TP5 for tpIdx=0)
+2=Time base is UTC (the variant according to the configuration in UBX-CFG-NAV5)</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>utc</name>
+              <description>0=UTC not available
+1=UTC available</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>time</name>
+              <description>0=Time is not valid
+1=Time is valid (Valid GNSS fix)</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>newRisingEdge</name>
+              <description>New rising edge detected</description>
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>count</name>
+          <type>U2</type>
+          <comment>Rising edge counter</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>wnR</name>
+          <type>U2</type>
+          <comment>Week number of last rising edge</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>wnF</name>
+          <type>U2</type>
+          <comment>Week number of last falling edge</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>towMsR</name>
+          <type>U4</type>
+          <comment>Tow of rising edge</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>towSubMsR</name>
+          <type>U4</type>
+          <comment>Millisecond fraction of tow of rising edge
+in nanoseconds</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>towMsF</name>
+          <type>U4</type>
+          <comment>Tow of falling edge</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>towSubMsF</name>
+          <type>U4</type>
+          <comment>Millisecond fraction of tow of falling edge
+in nanoseconds</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>accEst</name>
+          <type>U4</type>
+          <comment>Accuracy estimate</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-TOS</name>
+    <type>Periodic</type>
+    <description>Time pulse time and frequency data</description>
+    <comment>This message contains information about the time pulse that has just happened and the state of the disciplined oscillators(s) at the time of the pulse. It gives the UTC and GNSS times and time uncertainty of the pulse together with frequency and frequency uncertainty of the disciplined oscillators. It also supplies leap second information.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x12</id>
+      <length>56</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>gnssId</name>
+          <type>U1</type>
+          <comment>GNSS system used for reporting GNSS
+time (see Satellite Numbering)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>flags</name>
+          <type>X4</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>leapNow</name>
+              <description>1 = currently in a leap second</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>leapSoon</name>
+              <description>1 = leap second scheduled in current minute</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>leapPositive</name>
+              <description>1 = positive leap second</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>timeInLimit</name>
+              <description>1 = time pulse is within tolerance limit (UBX-CFG-SMGR timeTolerance field)</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>intOscInLimit</name>
+              <description>1 = internal oscillator is within tolerance limit (UBX-CFG-SMGR freqTolerance field)</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>extOscInLimit</name>
+              <description>1 = external oscillator is within tolerance limit (UBX-CFG-SMGR freqTolerance field)</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>gnssTimeValid</name>
+              <description>1 = GNSS time is valid</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>unsigned value</type>
+              <name>UTCTimeValid</name>
+              <description>1 = UTC time is valid</description>
+            </type>
+            <type>
+              <index>8:10</index>
+              <type>unsigned value</type>
+              <name>DiscSrc</name>
+              <description>Disciplining source identifier:
+0: internal oscillator
+1: GNSS
+2: EXTINT0
+3: EXTINT1
+4: internal oscillator measured by the host
+5: external oscillator measured by the host</description>
+            </type>
+            <type>
+              <index>11</index>
+              <type>unsigned value</type>
+              <name>raim</name>
+              <description>1 = (T)RAIM system is currently active. Note this flag only reports the current state of the GNSS
+solution; it is not affected by whether or not the GNSS solution is being used to discipline the
+oscillator.</description>
+            </type>
+            <type>
+              <index>12</index>
+              <type>unsigned value</type>
+              <name>cohPulse</name>
+              <description>1 = coherent pulse generation is currently in operation</description>
+            </type>
+            <type>
+              <index>13</index>
+              <type>unsigned value</type>
+              <name>lockedPulse</name>
+              <description>1 = time pulse is locked</description>
+            </type>
+            <type>
+              <index>14:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>year</name>
+          <type>U2</type>
+          <comment>Year of UTC time</comment>
+          <scale>-</scale>
+          <unit>y</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>month</name>
+          <type>U1</type>
+          <comment>Month of UTC time</comment>
+          <scale>-</scale>
+          <unit>month</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>day</name>
+          <type>U1</type>
+          <comment>Day of UTC time</comment>
+          <scale>-</scale>
+          <unit>d</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>hour</name>
+          <type>U1</type>
+          <comment>Hour of UTC time</comment>
+          <scale>-</scale>
+          <unit>h</unit>
+        </block>
+        <block>
+          <offset>13</offset>
+          <name>minute</name>
+          <type>U1</type>
+          <comment>Minute of UTC time</comment>
+          <scale>-</scale>
+          <unit>min</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>second</name>
+          <type>U1</type>
+          <comment>Second of UTC time</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>utcStandard</name>
+          <type>U1</type>
+          <comment>UTC standard identifier:
+0: unknown
+3: UTC as operated by the U.S. Naval
+Observatory (USNO)
+6: UTC as operated by the former Soviet
+Union
+7: UTC as operated by the National Time
+Service Center (NTSC), China</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>utcOffset</name>
+          <type>I4</type>
+          <comment>Time offset between the preceding pulse
+and UTC top of second</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>utcUncertainty</name>
+          <type>U4</type>
+          <comment>Uncertainty of utcOffset</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>week</name>
+          <type>U4</type>
+          <comment>GNSS week number</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>TOW</name>
+          <type>U4</type>
+          <comment>GNSS time of week</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>gnssOffset</name>
+          <type>I4</type>
+          <comment>Time offset between the preceding pulse
+and GNSS top of second</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>gnssUncertainty</name>
+          <type>U4</type>
+          <comment>Uncertainty of gnssOffset</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>intOscOffset</name>
+          <type>I4</type>
+          <comment>Internal oscillator frequency offset</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>intOscUncertainty</name>
+          <type>U4</type>
+          <comment>Internal oscillator frequency uncertainty</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>extOscOffset</name>
+          <type>I4</type>
+          <comment>External oscillator frequency offset</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>extOscUncertainty</name>
+          <type>U4</type>
+          <comment>External oscillator frequency uncertainty</comment>
+          <scale>2^-8</scale>
+          <unit>ppb</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-TP</name>
+    <type>Periodic/Polled</type>
+    <description>Time pulse time data</description>
+    <comment>This message contains information on the timing of the next pulse at the TIMEPULSE0 output. The recommended configuration when using this message is to set both the measurement rate (UBX-CFG-RATE) and the timepulse frequency (UBX-CFG-TP5) to 1 Hz. For more information see section Time pulse. TIMEPULSE0 and this message are not available from DR products using the dedicated I2C sensor interface, including NEO-M8L and NEO-M8U modules</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3 and 22</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x01</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>towMS</name>
+          <type>U4</type>
+          <comment>Time pulse time of week according to time
+base</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>towSubMS</name>
+          <type>U4</type>
+          <comment>Submillisecond part of towMS</comment>
+          <scale>2^-32</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>qErr</name>
+          <type>I4</type>
+          <comment>Quantization error of time pulse</comment>
+          <scale>-</scale>
+          <unit>ps</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>week</name>
+          <type>U2</type>
+          <comment>Time pulse week number according to
+time base</comment>
+          <scale>-</scale>
+          <unit>weeks</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>timeBase</name>
+              <description>0 = Time base is GNSS
+1 = Time base is UTC</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>utc</name>
+              <description>0 = UTC not available
+1 = UTC available</description>
+            </type>
+            <type>
+              <index>2:3</index>
+              <type>unsigned value</type>
+              <name>raim</name>
+              <description>(T)RAIM information
+0 = Information not available
+1 = Not active
+2 = Active</description>
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>qErrInvalid</name>
+              <description>0 = Quantization error valid
+1 = Quantization error invalid</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>15</offset>
+          <name>refInfo</name>
+          <type>X1</type>
+          <comment>Time reference information</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>unsigned value</type>
+              <name>timeRefGnss</name>
+              <description>GNSS reference information. Only valid if time base is GNSS (timeBase=0).
+0 = GPS
+1 = GLONASS
+2 = BeiDou
+3 = Galileo
+15 = Unknown</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>unsigned value</type>
+              <name>utcStandard</name>
+              <description>UTC standard identifier. Only valid if time base is UTC (timeBase=1).
+0 = Information not available
+1 = Communications Research Laboratory (CRL), Tokyo, Japan
+2 = National Institute of Standards and Technology (NIST)
+3 = U.S. Naval Observatory (USNO)
+4 = International Bureau of Weights and Measures (BIPM)
+5 = European laboratories
+6 = Former Soviet Union (SU)
+7 = National Time Service Center (NTSC), China
+15 = Unknown</description>
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-VCOCAL</name>
+    <type>Command</type>
+    <description>Stop calibration</description>
+    <comment>Stop all ongoing calibration (both oscillators are affected)</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x15</id>
+      <length>1</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (0 for this message)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-VCOCAL</name>
+    <type>Command</type>
+    <description>VCO calibration extended command</description>
+    <comment>Calibrate (measure) gain of the voltage controlled oscillator. The calibration is performed by varying the raw oscillator control values between the limits specified in raw0 and raw1. maxStepSize is the largest step change that can be used during the calibration process. The "raw values" are either PWM duty cycle values or DAC values depending on how the VCTCXO is connected to the system. The measured gain is the transfer function dRelativeFrequencyChange/dRaw (not dFrequency/dVoltage). The calibration process works as follows: Starting from the current raw output the control value is changed in the direction of raw0 in steps of size at most maxStepSize. Then the frequency is measured and the control value is changed towards raw1, again in steps of maxStepSize. When raw1 is reached, the frequency is again measured and the message version DATA0 is output containing the measured result. Normal operation then resumes. If the control value movement is less than maxStepSize then the transition will happen in one step - this will give fast calibration. Care must be taken when calibrating the internal oscillator against the GNSS source. In that case the changes applied to the oscillator frequency could be severe enough to lose satellite signal tracking, especially when signals are weak. If too many signals are lost, the GNSS system will lose its fix and be unable to measure the oscillator frequency - the calibration will then fail. In this case maxStepSize must be reasonably small. It is also important that only the chosen frequency source is enabled during the calibration process and that it remains stable throughout the calibration period; otherwise incorrect oscillator measurements will be made and this will lead to miscalibration and poor subsequent operation of the receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x15</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (2 for this message)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>oscId</name>
+          <type>U1</type>
+          <comment>Oscillator to be calibrated:
+0: internal oscillator
+1: external oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>srcId</name>
+          <type>U1</type>
+          <comment>Reference source:
+0: internal oscillator
+1: GNSS
+2: EXTINT0
+3: EXTINT1
+Option 0 should be used when calibrating
+the external oscillator. Options 1-3 should
+be used when calibrating the internal
+oscillator.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved1</name>
+          <type>U1[2]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>raw0</name>
+          <type>U2</type>
+          <comment>First value used for calibration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>raw1</name>
+          <type>U2</type>
+          <comment>Second value used for calibration</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>maxStepSize</name>
+          <type>U2</type>
+          <comment>Maximum step size to be used</comment>
+          <scale>-</scale>
+          <unit>rawvalue/s</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-VCOCAL</name>
+    <type>Periodic/Polled</type>
+    <description>Results of the calibration</description>
+    <comment>This message is sent when the oscillator gain calibration process is finished (successful or unsuccessful). It notifies the user of the calibrated oscillator gain. If the oscillator gain calibration process was successful, this message will contain the measured gain (field gainVco) and its uncertainty (field gainUncertainty). The calibration process can however fail. In that case the two fields gainVco and gainUncertainty are set to zero.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20. 2, 20.3, 22, 22.01, 23 and 23.01 (only with Time &amp; Frequency Sync products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x15</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Message type (3 for this message)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>oscId</name>
+          <type>U1</type>
+          <comment>Id of oscillator:
+0: internal oscillator
+1: external oscillator</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>gainUncertainty</name>
+          <type>U2</type>
+          <comment>Relative gain uncertainty after calibration,
+0 if calibration failed</comment>
+          <scale>2^-16</scale>
+          <unit>1/1</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>gainVco</name>
+          <type>I4</type>
+          <comment>Calibrated gain or 0 if calibration failed</comment>
+          <scale>2^-16</scale>
+          <unit>ppb/raw LSB</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-TIM-VRFY</name>
+    <type>Periodic/Polled</type>
+    <description>Sourced time verification</description>
+    <comment>This message contains verification information about previous time received via assistance data or from RTC.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0D</class>
+      <id>0x06</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>itow</name>
+          <type>I4</type>
+          <comment>integer millisecond tow received by source</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>frac</name>
+          <type>I4</type>
+          <comment>sub-millisecond part of tow</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>deltaMs</name>
+          <type>I4</type>
+          <comment>integer milliseconds of delta time (current
+time minus sourced time)</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>deltaNs</name>
+          <type>I4</type>
+          <comment>Sub-millisecond part of delta time</comment>
+          <scale>-</scale>
+          <unit>ns</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>wno</name>
+          <type>U2</type>
+          <comment>Week number</comment>
+          <scale>-</scale>
+          <unit>week</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>flags</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:2</index>
+              <type>unsigned value</type>
+              <name>src</name>
+              <description>Aiding time source
+0 = no time aiding done
+2 = source was RTC
+3 = source was assistance data</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>19</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-UPD-SOS</name>
+    <type>Poll Request</type>
+    <description>Poll backup restore status</description>
+    <comment>Sending this (empty) message to the receiver results in the receiver returning a System restored from backup message as defined below.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x09</class>
+      <id>0x14</id>
+      <length>0</length>
+      <payload />
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-UPD-SOS</name>
+    <type>Command</type>
+    <description>Create backup in flash</description>
+    <comment>The host can send this message in order to save part of the battery-backed memory (BBR) in a file in the flash file system. The feature is designed in order to emulate the presence of the backup battery even if it is not present; the host can issue the save on shutdown command before switching off the device supply. It is recommended to issue a GNSS stop command using UBX-CFG-RST before in order to keep the BBR memory content consistent.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x09</class>
+      <id>0x14</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>cmd</name>
+          <type>U1</type>
+          <comment>Command (must be 0)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-UPD-SOS</name>
+    <type>Command</type>
+    <description>Clear backup in flash</description>
+    <comment>The host can send this message in order to erase the backup file present in flash. It is recommended that the clear operation is issued after the host has received the notification that the memory has been restored after a reset. Alternatively the host can parse the startup string Restored data saved on shutdown or poll the UBX-UPD-SOS message for obtaining the status.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x09</class>
+      <id>0x14</id>
+      <length>4</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>cmd</name>
+          <type>U1</type>
+          <comment>Command (must be 1)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-UPD-SOS</name>
+    <type>Output</type>
+    <description>Backup creation acknowledge</description>
+    <comment>The message is sent from the device as confirmation of creation of a backup file in flash. The host can safely shut down the device after having received this message.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x09</class>
+      <id>0x14</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>cmd</name>
+          <type>U1</type>
+          <comment>Command (must be 2)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>response</name>
+          <type>U1</type>
+          <comment>0 = Not acknowledged
+1 = Acknowledged</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved2</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-UPD-SOS</name>
+    <type>Output</type>
+    <description>System restored from backup</description>
+    <comment>The message is sent from the device to notify the host the BBR has been restored from a backup file in the flash file sysetem. The host should clear the backup file after receiving this message. If the UBX-UPD-SOS message is polled, this message will be resent.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x09</class>
+      <id>0x14</id>
+      <length>8</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>cmd</name>
+          <type>U1</type>
+          <comment>Command (must be 3)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>response</name>
+          <type>U1</type>
+          <comment>0 = Unknown
+1 = Failed restoring from backup
+2 = Restored from backup
+3 = Not restored (no backup)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved2</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+</definitions>

--- a/ubx/messages.xml
+++ b/ubx/messages.xml
@@ -112,7 +112,7 @@ Almanac Data (Valid Range: 1 .. 32 or 51,
     <name>UBX-AID-ALM</name>
     <type>Input/Output</type>
     <description>GPS aiding almanac input/output message</description>
-    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead  If the WEEK Value is 0, DWRD0 to DWRD7 are not sent as the Almanac is not  available for the given SV. This may happen even if NAV-SVINFO and RXM-  SVSI are indicating almanac availability as the internal data may not represent  the content of an original broadcast almanac (or only parts thereof).  DWORD0 to DWORD7 contain the 8 words following the Hand-Over Word (  HOW ) from the GPS navigation message, either pages 1 to 24 of sub-frame 5 or  pages 2 to 10 of subframe 4. See IS-GPS-200 for a full description of the  contents of the Almanac pages.  In DWORD0 to DWORD7, the parity bits have been removed, and the 24 bits of  data are located in Bits 0 to 23. Bits 24 to 31 shall be ignored.  Example: Parameter e (Eccentricity) from Almanac Subframe 4/5, Word 3, Bits  69-84 within the subframe can be found in DWRD0, Bits 15-0 whereas Bit 0 is  the LSB.</comment>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead  If the WEEK Value is 0, DWRD0 to DWRD7 are not sent as the Almanac is not  available for the given SV. This may happen even if NAV-SVINFO and RXM-  SVSI are indicating almanac availability as the internal data may not represent  the content of an original broadcast almanac (or only parts thereof).  DWORD0 to DWORD7 contain the 8 words following the Hand-Over Word (  HOW ) from the GPS navigation message, either pages 1 to 24 of sub-frame 5  or pages 2 to 10 of subframe 4. See IS-GPS-200 for a full description of the  contents of the Almanac pages.  In DWORD0 to DWORD7, the parity bits have been removed, and the 24 bits of  data are located in Bits 0 to 23. Bits 24 to 31 shall be ignored.  Example: Parameter e (Eccentricity) from Almanac Subframe 4/5, Word 3, Bits  69-84 within the subframe can be found in DWRD0, Bits 15-0 whereas Bit 0 is  the LSB.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -285,7 +285,7 @@ Ephemeris Data (Valid Range: 1 .. 32).</comment>
     <name>UBX-AID-EPH</name>
     <type>Input/Output</type>
     <description>GPS aiding ephemeris input/output message</description>
-    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead  SF1D0 to SF3D7 is only sent if ephemeris is available for this SV. If not, the  payload may be reduced to 8 Bytes, or all bytes are set to zero, indicating that  this SV Number does not have valid ephemeris for the moment. This may  happen even if NAV-SVINFO and RXM-SVSI are indicating ephemeris  availability as the internal data may not represent the content of an original  broadcast ephemeris (or only parts thereof).  SF1D0 to SF3D7 contain the 24 words following the Hand-Over Word ( HOW )  from the GPS navigation message, subframes 1 to 3. The Truncated TOW  Count is not valid and cannot be used. See IS-GPS-200 for a full description of  the contents of the Subframes.  In SF1D0 to SF3D7, the parity bits have been removed, and the 24 bits of data  are located in Bits 0 to 23. Bits 24 to 31 shall be ignored.  When polled, the data contained in this message does not represent the full  original ephemeris broadcast. Some fields that are irrelevant to u-blox receivers  may be missing. The week number in Subframe 1 has already been modified to  match the Time Of Ephemeris (TOE).</comment>
+    <comment>All UBX-AID messages are deprecated; use UBX-MGA messages instead  SF1D0 to SF3D7 is only sent if ephemeris is available for this SV. If not, the  payload may be reduced to 8 Bytes, or all bytes are set to zero, indicating that  this SV Number does not have valid ephemeris for the moment. This may  happen even if NAV-SVINFO and RXM-SVSI are indicating ephemeris  availability as the internal data may not represent the content of an original  broadcast ephemeris (or only parts thereof).  SF1D0 to SF3D7 contain the 24 words following the Hand-Over Word ( HOW )  from the GPS navigation message, subframes 1 to 3. The Truncated TOW  Count is not valid and cannot be used. See IS-GPS-200 for a full description of  the contents of the Subframes.  In SF1D0 to SF3D7, the parity bits have been removed, and the 24 bits of data  are located in Bits 0 to 23. Bits 24 to 31 shall be ignored.  When polled, the data contained in this message does not represent the full  original ephemeris broadcast. Some fields that are irrelevant to u-blox  receivers may be missing. The week number in Subframe 1 has already been  modified to match the Time Of Ephemeris (TOE).</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -1631,6 +1631,483 @@ of oscillator control gain/slope</comment>
     </structure>
   </message>
   <message>
+    <name>UBX-CFG-ESFALG</name>
+    <type>Get/set</type>
+    <description>Get/set IMU-mount misalignment configuration</description>
+    <comment>Get/set the IMU-mount misalignment configuration (rotation from installation- frame to the IMU-frame). A detailed description on how to compose this configuration is given in the ADR Installation section for ADR products. A detailed description on how to compose this configuration is given in the UDR Installation section for UDR products.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16 and 17 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x56</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>bitfield</name>
+          <type>U4</type>
+          <comment>Bitfield</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:7</index>
+              <type>unsigned value</type>
+              <name>version</name>
+              <description>Message version (0x00 for this version)</description>
+            </type>
+            <type>
+              <index>8</index>
+              <type>unsigned value</type>
+              <name>doAutoMntAlg</name>
+              <description>Only supported on certain products.
+Enable/disable automatic IMU-mount alignment (0: Disabled, 1: Enabled). This flag can only be used
+with modules containing an internal IMU.</description>
+            </type>
+            <type>
+              <index>9:31</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>yaw</name>
+          <type>U4</type>
+          <comment>User-defined IMU-mount yaw angle [0,
+360]</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>pitch</name>
+          <type>I2</type>
+          <comment>User-defined IMU-mount pitch angle [-90,
+90]</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>roll</name>
+          <type>I2</type>
+          <comment>User-defined IMU-mount roll angle [-180,
+180]</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ESFA</name>
+    <type>Get/set</type>
+    <description>Get/set the Accelerometer (A) sensor configuration</description>
+    <comment>Get/set the configuration for the accelerometer sensor required for External Sensor Fusion (ESF) based navigation. More details can be found in the Accelerometer Configuration section.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x4C</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[9]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>accelRmsThdl</name>
+          <type>U1</type>
+          <comment>Accelerometer RMS threshold below
+which automatically estimated
+accelerometer noise-level (accuracy) is
+updated.</comment>
+          <scale>2^-6</scale>
+          <unit>m/s^2</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>frequency</name>
+          <type>U1</type>
+          <comment>Nominal accelerometer sensor data
+sampling frequency.</comment>
+          <scale>-</scale>
+          <unit>Hz</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>latency</name>
+          <type>U2</type>
+          <comment>Accelerometer sensor data latency due to
+e.g. CAN bus.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>accuracy</name>
+          <type>U2</type>
+          <comment>Accelerometer sensor data accuracy.</comment>
+          <scale>1e-4</scale>
+          <unit>m/s^2</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ESFG</name>
+    <type>Get/set</type>
+    <description>Get/set the Gyroscope (G) sensor configuration</description>
+    <comment>Get/set the configuration for the gyroscope sensor required for External Sensor Fusion (ESF) based navigation. More details can be found in the Gyroscope Configuration section.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x4D</id>
+      <length>20</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1[7]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>tcTableSaveRate</name>
+          <type>U2</type>
+          <comment>Temperature-dependent gyroscope bias
+table saving update rate.</comment>
+          <scale>-</scale>
+          <unit>s</unit>
+        </block>
+        <block>
+          <offset>10</offset>
+          <name>gyroRmsThdl</name>
+          <type>U1</type>
+          <comment>Gyroscope sensor RMS threshold below
+which automatically estimated gyroscope
+noise-level (accuracy) is updated.</comment>
+          <scale>2^-8</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>11</offset>
+          <name>frequency</name>
+          <type>U1</type>
+          <comment>Nominal gyroscope sensor data sampling
+frequency.</comment>
+          <scale>-</scale>
+          <unit>Hz</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>latency</name>
+          <type>U2</type>
+          <comment>Gyroscope sensor data latency due to e.g.
+CAN bus.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>accuracy</name>
+          <type>U2</type>
+          <comment>Gyroscope sensor data accuracy.</comment>
+          <scale>1e-3</scale>
+          <unit>deg/s</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>reserved2</name>
+          <type>U1[4]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-ESFWT</name>
+    <type>Get/set</type>
+    <description>Get/set wheel-tick configuration</description>
+    <comment>Get/set the wheel-tick configuration for GWT or GAWT solution. Further information on the configuration parameters is given in the Automotive Dead Reckoning (ADR) chapter. This field can only be used with modules supporting analog wheel-tick signals and containing an internal IMU.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x82</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>flags1</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>combineTicks</name>
+              <description>Use combined rear wheel-ticks instead of the single tick</description>
+            </type>
+            <type>
+              <index>1:3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>useWtSpeed</name>
+              <description>Use speed measurements (data type 11 in ESF-MEAS) instead of single ticks (data type 10)</description>
+            </type>
+            <type>
+              <index>5</index>
+              <type>unsigned value</type>
+              <name>dirPinPol</name>
+              <description>Only supported on certain products.
+Direction pin polarity
+0: High signal level means forward direction,
+1: High signal level means backward direction.</description>
+            </type>
+            <type>
+              <index>6</index>
+              <type>unsigned value</type>
+              <name>useWtPin</name>
+              <description>Use wheel-tick pin for speed measurement.</description>
+            </type>
+            <type>
+              <index>7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>flags2</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>autoWtCountMaxOff</name>
+              <description>Disable automatic estimation of maximum absolute wheel-tick counter value (0: enabled, 1: disabled). See wtCountMax field description for more details.
+(Not supported in protocol versions less than 19)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>autoDirPinPolOff</name>
+              <description>Only supported on certain products. Disable automatic wheel-tick direction pin polarity detection (0: enabled, 1: disabled). See dirPinPol
+field description for more details.
+(Not supported in protocol versions less than 19)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>autoSoftwareWtOff</name>
+              <description>Only supported on certain products. Disable automatic use of wheel-tick or speed data received over the software interface if available (0:
+enabled, 1: disabled). In this case, data coming from the hardware interface (wheel-tick pins) will
+automatically be ignored if wheel-tick/speed data are available from the software interface. See
+useWtPin field description for more details.
+(Not supported in protocol versions less than 19)</description>
+            </type>
+            <type>
+              <index>3</index>
+              <type>unsigned value</type>
+              <name>autoUseWtSpeedOff</name>
+              <description>Disable automatic receiver reconfiguration for processing speed data instead of wheel-tick data if no wheel-tick data are available but speed data were detected (0: enabled, 1: disabled). See useWtSpeed
+field description for more details.
+(Not supported in protocol versions less than 19)</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1[1]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>wtFactor</name>
+          <type>U4</type>
+          <comment>Wheel-tick scale factor to obtain distance
+[m] from wheel-ticks (0 = not set)</comment>
+          <scale>1e-6</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>wtQuantError</name>
+          <type>U4</type>
+          <comment>Wheel-tick quantization. If useWtSpeed is
+set then this is interpreted as the speed
+measurement error RMS.</comment>
+          <scale>1e-6</scale>
+          <unit>m (orm/s)</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>wtCountMax</name>
+          <type>U4</type>
+          <comment>Wheel-tick counter maximum value
+(rollover - 1). If null, relative wheel-tick
+counts are assumed (and therefore no
+rollover). If not null, absolute wheel-tick
+counts are assumed and the value
+corresponds to the highest tick count
+value before rollover happens. If
+useWtSpeed is set then this value is
+ignored.
+If value is set to 1, absolute wheel-tick
+counts are assumed and the value will be
+automatic calculated if possible. It is only
+possible for automatic calibration to
+calculate wtCntMax if it can be
+represented as a number of set bits (i.e.
+2^N). If it cannot be represented in this
+way it must be set to the correct absolute
+tick value manually.</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>wtLatency</name>
+          <type>U2</type>
+          <comment>Wheel-tick data latency due to e.g. CAN
+bus</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>18</offset>
+          <name>wtFrequency</name>
+          <type>U1</type>
+          <comment>Nominal wheel-tick data frequency (0 =
+not set)</comment>
+          <scale>-</scale>
+          <unit>Hz</unit>
+        </block>
+        <block>
+          <offset>19</offset>
+          <name>flags3</name>
+          <type>X1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:3</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+            <type>
+              <index>4</index>
+              <type>unsigned value</type>
+              <name>cntBothEdges</name>
+              <description>Only supported on certain products.
+Count both rising and falling edges on wheel-tick signal (only relevant if wheel-tick is measured by
+the u-blox receiver).
+Only turn on this feature if the wheel-tick signal has 50 % duty cycle. Turning on this feature with
+fixed-width pulses can lead to severe degradation of performance.
+Use wheel-tick pin for speed measurement. This field can only be used with modules supporting
+analog wheel-tick signals.</description>
+            </type>
+            <type>
+              <index>5:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>speedDeadBand</name>
+          <type>U2</type>
+          <comment>Speed sensor dead band (0 = not set)</comment>
+          <scale>-</scale>
+          <unit>cm/s</unit>
+        </block>
+        <block>
+          <offset>22</offset>
+          <name>reserved2</name>
+          <type>U1[10]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
     <name>UBX-CFG-ESRC</name>
     <type>Get/set</type>
     <description>External synchronization source configuration</description>
@@ -1943,7 +2420,7 @@ always high.</comment>
     <name>UBX-CFG-GNSS</name>
     <type>Get/set</type>
     <description>GNSS system configuration</description>
-    <comment>Gets or sets the GNSS system channel sharing configuration. If the receiver is sent a valid new configuration, it will respond with a UBX-ACK- ACK message and immediately change to the new configuration. Otherwise the receiver will reject the request, by issuing a UBX-ACK-NAK and continuing operation with the previous configuration. Configuration requirements:  It is necessary for at least one major GNSS to be enabled, after applying the  new configuration to the current one.  It is also required that at least 4 tracking channels are available to each enabled  major GNSS, i.e. maxTrkCh must have a minimum value of 4 for each enabled  major GNSS.  The number of tracking channels in use must not exceed the number of  tracking channels available in hardware, and the sum of all reserved tracking  channels needs to be less than or equal to the number of tracking channels in  use. Notes:  To avoid cross-correlation issues, it is recommended that GPS and QZSS are  always both enabled or both disabled.  Polling this message returns the configuration of all supported GNSS, whether  enabled or not; it may also include GNSS unsupported by the particular  product, but in such cases the enable flag will always be unset.  See section GNSS Configuration for a discussion of the use of this message.  See section Satellite Numbering for a description of the GNSS IDs available.  Configuration specific to the GNSS system can be done via other messages (e.  g. UBX-CFG-SBAS).</comment>
+    <comment>Gets or sets the GNSS system channel sharing configuration. If the receiver is sent a valid new configuration, it will respond with a UBX-ACK- ACK message and immediately change to the new configuration. Otherwise the receiver will reject the request, by issuing a UBX-ACK-NAK and continuing operation with the previous configuration. Configuration requirements:  It is necessary for at least one major GNSS to be enabled, after applying the  new configuration to the current one.  It is also required that at least 4 tracking channels are available to each  enabled major GNSS, i.e. maxTrkCh must have a minimum value of 4 for each  enabled major GNSS.  The number of tracking channels in use must not exceed the number of  tracking channels available in hardware, and the sum of all reserved tracking  channels needs to be less than or equal to the number of tracking channels in  use. Notes:  To avoid cross-correlation issues, it is recommended that GPS and QZSS are  always both enabled or both disabled.  Polling this message returns the configuration of all supported GNSS, whether  enabled or not; it may also include GNSS unsupported by the particular  product, but in such cases the enable flag will always be unset.  See section GNSS Configuration for a discussion of the use of this message.  See section Satellite Numbering for a description of the GNSS IDs available.  Configuration specific to the GNSS system can be done via other messages (e.  g. UBX-CFG-SBAS).</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -2058,20 +2535,24 @@ be configured in every enabled system.</comment>
 When gnssId is 0 (GPS)
 0x01 = GPS L1C/A
 0x10 = GPS L2C
+0x20 = GPS L5
 When gnssId is 1 (SBAS)
 0x01 = SBAS L1C/A
 When gnssId is 2 (Galileo)
 0x01 = Galileo E1 (not supported in protocol versions less than 18)
+0x10 = Galileo E5a
 0x20 = Galileo E5b
 When gnssId is 3 (BeiDou)
 0x01 = BeiDou B1I
 0x10 = BeiDou B2I
+0x80 = BeiDou B2A
 When gnssId is 4 (IMES)
 0x01 = IMES L1
 When gnssId is 5 (QZSS)
 0x01 = QZSS L1C/A
 0x04 = QZSS L1S
 0x10 = QZSS L2C
+0x20 = QZSS L5
 When gnssId is 6 (GLONASS)
 0x01 = GLONASS L1
 0x10 = GLONASS L2</description>
@@ -2093,7 +2574,7 @@ When gnssId is 6 (GLONASS)
     <name>UBX-CFG-HNR</name>
     <type>Get/set</type>
     <description>High navigation rate settings</description>
-    <comment>The u-blox receivers support high rates of navigation update up to 30 Hz. The navigation solution output UBX-NAV-HNR will not be aligned to the top of a second.  The update rate has a direct influence on the power consumption. The more  fixes that are required, the more CPU power and communication resources are   required.   For most applications a 1 Hz update rate would be sufficient.</comment>
+    <comment>The u-blox receivers support high rates of navigation update up to 30 Hz. The navigation solution output UBX-NAV-HNR will not be aligned to the top of a second.  The update rate has a direct influence on the power consumption. The more  fixes that are required, the more CPU power and communication resources are  required.  For most applications a 1 Hz update rate would be sufficient.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16 and 17 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -2154,7 +2635,7 @@ following are valid protocol identifiers:
     <name>UBX-CFG-INF</name>
     <type>Get/set</type>
     <description>Information message configuration</description>
-    <comment>The value of infMsgMask[x] below is formed so that each bit represents one of the INF class messages (bit 0 for ERROR, bit 1 for WARNING and so on). For a complete list, see the Message class INF. Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length. Output messages from the module contain only one configuration unit. Note that:   I/O ports 1 and 2 correspond to serial ports 1 and 2.   I/O port 0 is I2C (DDC).   I/O port 3 is USB.   I/O port 4 is SPI.   I/O port 5 is reserved for future use.</comment>
+    <comment>The value of infMsgMask[x] below is formed so that each bit represents one of the INF class messages (bit 0 for ERROR, bit 1 for WARNING and so on). For a complete list, see the Message class INF. Several configurations can be concatenated to one input message. In this case the payload length can be a multiple of the normal length. Output messages from the module contain only one configuration unit. Note that:  I/O ports 1 and 2 correspond to serial ports 1 and 2.  I/O port 0 is I2C (DDC).  I/O port 3 is USB.  I/O port 4 is SPI.  I/O port 5 is reserved for future use.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -2460,7 +2941,7 @@ applies.</comment>
     <name>UBX-CFG-MSG</name>
     <type>Get/set</type>
     <description>Set message rate(s)</description>
-    <comment>Get/set message rate configuration (s) to/from the receiver. See also section How to change between protocols.  Send rate is relative to the event a message is registered on. For example, if the  rate of a navigation message is set to 2, the message is sent every second  navigation solution. For configuring NMEA messages, the section NMEA  Messages Overview describes class and identifier numbers used.</comment>
+    <comment>Get/set message rate configuration (s) to/from the receiver. See also section How to change between protocols.  Send rate is relative to the event a message is registered on. For example, if  the rate of a navigation message is set to 2, the message is sent every second  navigation solution. For configuring NMEA messages, the section NMEA  Messages Overview describes class and identifier numbers used.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -6847,11 +7328,96 @@ Every bit corresponds to a PRN number.</comment>
     </structure>
   </message>
   <message>
+    <name>UBX-CFG-SENIF</name>
+    <type>Get/set</type>
+    <description>I2C sensor interface configuration</description>
+    <comment>-</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x88</id>
+      <length>6</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>type</name>
+          <type>U1</type>
+          <comment>Type of interface, 0 for I2C</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version, 0 for this message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>flags</name>
+          <type>X2</type>
+          <comment>feature configuration flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>senConn</name>
+              <description>Sensor is connected to I2C interface</description>
+            </type>
+            <type>
+              <index>1:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>pioConf</name>
+          <type>X2</type>
+          <comment>PIO configuration flags (see graphic below
+)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0:4</index>
+              <type>unsigned value</type>
+              <name>i2cSdaPio</name>
+              <description>PIO of the I2C SDA line
+Supported options:</description>
+            </type>
+            <type>
+              <index>5:9</index>
+              <type>unsigned value</type>
+              <name>i2cSclPio</name>
+              <description>PIO of the I2C SCL line
+Supported options:</description>
+            </type>
+            <type>
+              <index>10:15</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
     <name>UBX-CFG-SLAS</name>
     <type>Get/set</type>
     <description>SLAS configuration</description>
     <comment>This message configures the QZSS SLAS (Sub-meter Level Augmentation System). See the SLAS Configuration Settings Description for a detailed description of how these settings affect receiver operation. To apply SLAS corrections, QZSS operation and L1S signal tracking must be enabled see UBX-CFG-GNSS</comment>
-    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 19.2 (only with ADR or UDR products)</firmware>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 19.2 (only with ADR or UDR products )</firmware>
     <structure>
       <header>0xB5 0x62</header>
       <class>0x06</class>
@@ -7165,6 +7731,55 @@ switch to coherent pulse mode.</description>
               <description />
             </type>
           </bitfield>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-CFG-SPT</name>
+    <type>Get/set</type>
+    <description>Configure and start a sensor production test</description>
+    <comment>The production test uses the built-in self-test capabilities of an attached sensor. This message is only supported if a sensor is directly connected to the u-blox receiver.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR products) u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x06</class>
+      <id>0x64</id>
+      <length>12</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>sensorId</name>
+          <type>U2</type>
+          <comment>ID of the sensor to be tested; see UBX-
+MON-SPT for defined IDs</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>reserved2</name>
+          <type>U1[8]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
         </block>
       </payload>
       <checksum>CK_A CK_B</checksum>
@@ -8099,6 +8714,139 @@ Host drivers.</comment>
     </structure>
   </message>
   <message>
+    <name>UBX-ESF-ALG</name>
+    <type>Periodic/Polled</type>
+    <description>IMU alignment information</description>
+    <comment>This message outputs the IMU alignment angles which define the rotation from the installation-frame to the IMU-frame (see the IMU-mount Misalignment section for more details). In addition, it outputs information about the automatic IMU-mount alignment (if enabled).</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x10</class>
+      <id>0x14</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>flags</name>
+          <type>U1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>autoMntAlgOn</name>
+              <description>Automatic IMU-mount alignment on/off bit (0: automatic alignment is not running, 1: automatic
+alignment is running)</description>
+            </type>
+            <type>
+              <index>1:3</index>
+              <type>unsigned value</type>
+              <name>status</name>
+              <description>Status of the IMU-mount alignment (0: user-defined/fixed angles are used, 1: IMU-mount roll/pitch
+angles alignment is ongoing, 2: IMU-mount roll/pitch/yaw angles alignment is ongoing, 3: coarse
+IMU-mount alignment are used, 4: fine IMU-mount alignment are used)</description>
+            </type>
+            <type>
+              <index>4:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>error</name>
+          <type>U1</type>
+          <comment>Flags</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+          <bitfield>
+            <type>
+              <index>0</index>
+              <type>unsigned value</type>
+              <name>tiltAlgError</name>
+              <description>IMU-mount tilt (roll and/or pitch) alignment error (0: no error, 1: error)</description>
+            </type>
+            <type>
+              <index>1</index>
+              <type>unsigned value</type>
+              <name>yawAlgError</name>
+              <description>IMU-mount yaw alignment error (0: no error, 1: error)</description>
+            </type>
+            <type>
+              <index>2</index>
+              <type>unsigned value</type>
+              <name>angleError</name>
+              <description>IMU-mount misalignment Euler angle singularity error (0: no error, 1: error). If this error bit is set, the
+IMU-mount roll and IMU-mount yaw angles cannot uniquely be defined due to the singularity issue
+happening with installations mounted with a +/- 90 degrees misalignment around pitch axis. This is
+also known as the 'gimbal-lock' problem affecting rotations described by Euler angles.</description>
+            </type>
+            <type>
+              <index>3:7</index>
+              <type>reserved</type>
+              <name />
+              <description />
+            </type>
+          </bitfield>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>yaw</name>
+          <type>U4</type>
+          <comment>IMU-mount yaw angle [0, 360]</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>pitch</name>
+          <type>I2</type>
+          <comment>IMU-mount pitch angle [-90, 90]</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>14</offset>
+          <name>roll</name>
+          <type>I2</type>
+          <comment>IMU-mount roll angle [-180, 180]</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
     <name>UBX-ESF-INS</name>
     <type>Periodic/Polled</type>
     <description>Vehicle dynamics information</description>
@@ -8600,6 +9348,97 @@ calibrated.</description>
               </type>
             </bitfield>
           </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-HNR-ATT</name>
+    <type>Periodic/Polled</type>
+    <description>Attitude solution</description>
+    <comment>This message outputs the attitude solution as roll, pitch and heading angles. More details about vehicle attitude can be found in the Vehicle Attitude Output (ADR) section for ADR products. More details about vehicle attitude can be found in the Vehicle Attitude Output (UDR) section for UDR products.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 with protocol version 19.2 (only with ADR or UDR products )</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x28</class>
+      <id>0x01</id>
+      <length>32</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the HNR epoch.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1[3]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>roll</name>
+          <type>I4</type>
+          <comment>Vehicle roll.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>pitch</name>
+          <type>I4</type>
+          <comment>Vehicle pitch.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>heading</name>
+          <type>I4</type>
+          <comment>Vehicle heading.</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>accRoll</name>
+          <type>U4</type>
+          <comment>Vehicle roll accuracy (if null, roll angle is
+not available).</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>accPitch</name>
+          <type>U4</type>
+          <comment>Vehicle pitch accuracy (if null, pitch angle
+is not available).</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>accHeading</name>
+          <type>U4</type>
+          <comment>Vehicle heading accuracy (if null, heading
+angle is not available).</comment>
+          <scale>1e-5</scale>
+          <unit>deg</unit>
         </block>
       </payload>
       <checksum>CK_A CK_B</checksum>
@@ -9196,7 +10035,7 @@ See the description of iTOW for details.</comment>
               <index>0</index>
               <type>unsigned value</type>
               <name>extraPvt</name>
-              <description>Store extra PVT information
+              <description>Extra PVT information is valid
 The fields iTOW, tAcc, numSV, hMSL, vAcc, velN, velE, velD, sAcc, headAcc and pDOP are only valid if
 this flag is set.</description>
             </type>
@@ -9204,7 +10043,7 @@ this flag is set.</description>
               <index>1</index>
               <type>unsigned value</type>
               <name>extraOdo</name>
-              <description>Store odometer data
+              <description>Odometer data is valid
 The fields distance, totalDistance and distanceStd are only valid if this flag is set.
 Note: the odometer feature itself must also be enabled.</description>
             </type>
@@ -9830,7 +10669,7 @@ is zero-based.</comment>
     <name>UBX-LOG-INFO</name>
     <type>Output</type>
     <description>Log information</description>
-    <comment>This message is used to report information about the logging subsystem. Note:  The reported maximum log size will be smaller than that originally specified in  LOG-CREATE due to logging and filestore implementation overheads.  Log entries are compressed in a variable length fashion, so it may be difficult to  predict log space usage with any precision.  There may be times when the receiver does not have an accurate time (e.g. if  the week number is not yet known), in which case some entries will not have a  timestamp. This may result in the oldest/newest entry time values not taking  account of these entries.</comment>
+    <comment>This message is used to report information about the logging subsystem. Note:  The reported maximum log size will be smaller than that originally specified in  LOG-CREATE due to logging and filestore implementation overheads.  Log entries are compressed in a variable length fashion, so it may be difficult  to predict log space usage with any precision.  There may be times when the receiver does not have an accurate time (e.g. if  the week number is not yet known), in which case some entries will not have a  timestamp. This may result in the oldest/newest entry time values not taking  account of these entries.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -14949,7 +15788,7 @@ receiver</comment>
     <name>UBX-MON-HW2</name>
     <type>Periodic/Polled</type>
     <description>Extended hardware status</description>
-    <comment>Status of different aspects of the hardware such as Imbalance, Low-Level Configuration and POST Results. The first four parameters of this message represent the complex signal from the RF front end. The following rules of thumb apply:  The smaller the absolute value of the variable ofsI and ofsQ, the better.  Ideally, the magnitude of the I-part (magI) and the Q-part (magQ) of the complex  signal should be the same.</comment>
+    <comment>Status of different aspects of the hardware such as Imbalance, Low-Level Configuration and POST Results. The first four parameters of this message represent the complex signal from the RF front end. The following rules of thumb apply:  The smaller the absolute value of the variable ofsI and ofsQ, the better.  Ideally, the magnitude of the I-part (magI) and the Q-part (magQ) of the  complex signal should be the same.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -15816,6 +16655,221 @@ external input 1</comment>
     </structure>
   </message>
   <message>
+    <name>UBX-MON-SPT</name>
+    <type>Polled</type>
+    <description>Sensor production test</description>
+    <comment>This message reports the state of, and measurements made during, sensor self- tests. This message can also be used to retrieve information about detected sensor(s) and driver(s) used. This message is only supported if a sensor is directly connected to the u-blox chip. This includes modules that contain IMUs. Note that this message shows the status of the last self-test since sensor startup. The self-test results are not stored in non-volatile memory.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR or UDR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x0A</class>
+      <id>0x2F</id>
+      <length>4 + 12*numRes + 4*numSensor</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x01 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>1</offset>
+          <name>numSensor</name>
+          <type>U1</type>
+          <comment>number of sensors reported in this
+message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>2</offset>
+          <name>numRes</name>
+          <type>U1</type>
+          <comment>number of result items reported in this
+message</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>3</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block name="numSensor" type="repeated">
+          <block>
+            <offset>4 + 4*N</offset>
+            <name>sensorId</name>
+            <type>U1</type>
+            <comment>Sensor ID
+The following IDs are defined, others are
+reserved:
+1: ST LSM6DS0 6-axis IMU with
+temperature sensor
+2: Invensense MPU6500 6-axis IMU with
+temperature sensor
+3: Bosch BMI160 6-axis IMU with
+temperature sensor
+7: ST LSM6DS3 6-axis IMU with
+temperature sensor
+9: Bosch SMI130 6-axis IMU with
+temperature sensor
+12: MPU6515, 6-axis inertial sensor from
+Invensense
+13: ST LSM6DSL 6-axis IMU with
+temperature sensor
+14: SMG130, 3-axis gyroscope with
+temperature sensor from Bosch
+15: SMI230, 6-axis IMU with temperature
+sensor from Bosch
+16: BMI260, 6-axis IMU with temperature
+sensor from Bosch
+17: ICM330DLC, 6-axis IMU with
+temperature sensor from ST
+18: ICM330DHCX, 6-axis IMU with 105 deg
+temperature sensor from ST
+Not all sensors are supported in any
+released firmware. Refer to the release
+notes to find out which sensor is
+supported by a certain firmware.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>5 + 4*N</offset>
+            <name>drvVer</name>
+            <type>X1</type>
+            <comment>Version information</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+            <bitfield>
+              <type>
+                <index>0:3</index>
+                <type>unsigned value</type>
+                <name>drvVerMaj</name>
+                <description>Driver major version</description>
+              </type>
+              <type>
+                <index>4:7</index>
+                <type>unsigned value</type>
+                <name>drvVerMin</name>
+                <description>Driver minor version</description>
+              </type>
+            </bitfield>
+          </block>
+          <block>
+            <offset>6 + 4*N</offset>
+            <name>testState</name>
+            <type>U1</type>
+            <comment>State of one sensor's test, it can be
+0: test not yet started
+1: test started but not yet finished
+2: test did not finish due to error during
+execution
+3: test finished normally, test data is
+available</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>7 + 4*N</offset>
+            <name>drvFileName</name>
+            <type>U1</type>
+            <comment>0 if the active driver is loaded from image,
+last character of the file name if it is
+loaded from separate file.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+        <block name="numRes" type="repeated">
+          <block>
+            <offset>4 + 12*N + 4*numSensor</offset>
+            <name>sensorIdRes</name>
+            <type>U2</type>
+            <comment>Sensor ID; eligible values are the same as
+in sensorIdState field</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>6 + 12*N + 4*numSensor</offset>
+            <name>sensorType</name>
+            <type>U2</type>
+            <comment>Sensor type and axis (if applicable) to
+which the result refers
+The following values are defined, others
+are reserved:
+5: Gyroscope z axis
+12: Gyroscope temperature
+13: Gyroscope y axis
+14: Gyroscope x axis
+16: Accelerometer x axis
+17: Accelerometer y axis
+18: Accelerometer z axis
+19: Barometer
+22: Magnetometer x axis
+23: Magnetometer y axis
+24: Magnetometer z axis
+25: Barometer temperature</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>8 + 12*N + 4*numSensor</offset>
+            <name>resType</name>
+            <type>U2</type>
+            <comment>The type of result stored in the value field
+1: Measurement without self-test offset
+(raw and unscaled digital value)
+2: Measurement with positive self-test
+offset (raw and unscaled digital value)
+3: Measurement with negative self-test
+offset (raw and unscaled digital value)
+4: Minimum off-to-positive to pass self-
+test, as deduced from on-chip trimming
+information
+5: Maximum off-to-positive to pass self-
+test, as deduced from on-chip trimming
+information
+6: Minimum negative-to-positive to pass
+self-test, as deduced from on-chip
+trimming information
+7: Maximum negative-to-positive to pass
+self-test, as deduced from on-chip
+trimming information
+8: Self-test passed; test passed if value = 1
+and failed if 0. Used if the decision is read
+out from the sensor itself.</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>10 + 12*N + 4*numSensor</offset>
+            <name>reserved2</name>
+            <type>U1[2]</type>
+            <comment>Reserved</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+          <block>
+            <offset>12 + 12*N + 4*numSensor</offset>
+            <name>value</name>
+            <type>I4</type>
+            <comment>value of the specific test result</comment>
+            <scale>-</scale>
+            <unit>-</unit>
+          </block>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
     <name>UBX-MON-TXBUF</name>
     <type>Periodic/Polled</type>
     <description>Transmitter buffer status</description>
@@ -16199,6 +17253,159 @@ See the description of iTOW for details.</comment>
     </structure>
   </message>
   <message>
+    <name>UBX-NAV-COV</name>
+    <type>Periodic/Polled</type>
+    <description>Covariance matrices</description>
+    <comment>This message outputs the covariance matrices for the position and velocity solutions in the topocentric coordinate system defined as the local-level North (N), East (E), Down (D) frame. As the covariance matrices are symmetric, only the upper triangular part is output.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x36</id>
+      <length>64</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>posCovValid</name>
+          <type>U1</type>
+          <comment>Position covariance matrix validity flag</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>velCovValid</name>
+          <type>U1</type>
+          <comment>Velocity covariance matrix validity flag</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>7</offset>
+          <name>reserved1</name>
+          <type>U1[9]</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>16</offset>
+          <name>posCovNN</name>
+          <type>R4</type>
+          <comment>Position covariance matrix value p_NN</comment>
+          <scale>-</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>20</offset>
+          <name>posCovNE</name>
+          <type>R4</type>
+          <comment>Position covariance matrix value p_NE</comment>
+          <scale>-</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>24</offset>
+          <name>posCovND</name>
+          <type>R4</type>
+          <comment>Position covariance matrix value p_ND</comment>
+          <scale>-</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>28</offset>
+          <name>posCovEE</name>
+          <type>R4</type>
+          <comment>Position covariance matrix value p_EE</comment>
+          <scale>-</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>32</offset>
+          <name>posCovED</name>
+          <type>R4</type>
+          <comment>Position covariance matrix value p_ED</comment>
+          <scale>-</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>36</offset>
+          <name>posCovDD</name>
+          <type>R4</type>
+          <comment>Position covariance matrix value p_DD</comment>
+          <scale>-</scale>
+          <unit>m^2</unit>
+        </block>
+        <block>
+          <offset>40</offset>
+          <name>velCovNN</name>
+          <type>R4</type>
+          <comment>Velocity covariance matrix value v_NN</comment>
+          <scale>-</scale>
+          <unit>m^2/s^2</unit>
+        </block>
+        <block>
+          <offset>44</offset>
+          <name>velCovNE</name>
+          <type>R4</type>
+          <comment>Velocity covariance matrix value v_NE</comment>
+          <scale>-</scale>
+          <unit>m^2/s^2</unit>
+        </block>
+        <block>
+          <offset>48</offset>
+          <name>velCovND</name>
+          <type>R4</type>
+          <comment>Velocity covariance matrix value v_ND</comment>
+          <scale>-</scale>
+          <unit>m^2/s^2</unit>
+        </block>
+        <block>
+          <offset>52</offset>
+          <name>velCovEE</name>
+          <type>R4</type>
+          <comment>Velocity covariance matrix value v_EE</comment>
+          <scale>-</scale>
+          <unit>m^2/s^2</unit>
+        </block>
+        <block>
+          <offset>56</offset>
+          <name>velCovED</name>
+          <type>R4</type>
+          <comment>Velocity covariance matrix value v_ED</comment>
+          <scale>-</scale>
+          <unit>m^2/s^2</unit>
+        </block>
+        <block>
+          <offset>60</offset>
+          <name>velCovDD</name>
+          <type>R4</type>
+          <comment>Velocity covariance matrix value v_DD</comment>
+          <scale>-</scale>
+          <unit>m^2/s^2</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
     <name>UBX-NAV-DGPS</name>
     <type>Periodic/Polled</type>
     <description>DGPS data used for NAV</description>
@@ -16341,7 +17548,7 @@ having channel number 15</description>
     <name>UBX-NAV-DOP</name>
     <type>Periodic/Polled</type>
     <description>Dilution of precision</description>
-    <comment>DOP values are dimensionless. All DOP values are scaled by a factor of 100. If the unit transmits a value of e.g. 156, the DOP value is 1.56.</comment>
+    <comment> DOP values are dimensionless.  All DOP values are scaled by a factor of 100. If the unit transmits a value of e.g.  156, the DOP value is 1.56.</comment>
     <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 15, 15.01, 16, 17, 18, 19, 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
     <structure>
       <header>0xB5 0x62</header>
@@ -16413,6 +17620,72 @@ See the description of iTOW for details.</comment>
           <comment>Easting DOP</comment>
           <scale>0.01</scale>
           <unit>-</unit>
+        </block>
+      </payload>
+      <checksum>CK_A CK_B</checksum>
+    </structure>
+  </message>
+  <message>
+    <name>UBX-NAV-EELL</name>
+    <type>Periodic/Polled</type>
+    <description>Position error ellipse parameters</description>
+    <comment>This message outputs the error ellipse parameters for the position solutions.</comment>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 19.1, 19.2, 20, 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01 (only with ADR products)</firmware>
+    <structure>
+      <header>0xB5 0x62</header>
+      <class>0x01</class>
+      <id>0x3d</id>
+      <length>16</length>
+      <payload>
+        <block>
+          <offset>0</offset>
+          <name>iTOW</name>
+          <type>U4</type>
+          <comment>GPS time of week of the navigation epoch.
+See the description of iTOW for details.</comment>
+          <scale>-</scale>
+          <unit>ms</unit>
+        </block>
+        <block>
+          <offset>4</offset>
+          <name>version</name>
+          <type>U1</type>
+          <comment>Message version (0x00 for this version)</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>5</offset>
+          <name>reserved1</name>
+          <type>U1</type>
+          <comment>Reserved</comment>
+          <scale>-</scale>
+          <unit>-</unit>
+        </block>
+        <block>
+          <offset>6</offset>
+          <name>errEllipseOrient</name>
+          <type>U2</type>
+          <comment>Orientation of semi-major axis of error
+ellipse (degrees from true north)</comment>
+          <scale>1e-2</scale>
+          <unit>deg</unit>
+        </block>
+        <block>
+          <offset>8</offset>
+          <name>errEllipseMajor</name>
+          <type>U4</type>
+          <comment>Semi-major axis of error ellipse</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
+        </block>
+        <block>
+          <offset>12</offset>
+          <name>errEllipseMinor</name>
+          <type>U4</type>
+          <comment>Semi-minor axis of error ellipse</comment>
+          <scale>-</scale>
+          <unit>mm</unit>
         </block>
       </payload>
       <checksum>CK_A CK_B</checksum>
@@ -16532,7 +17805,7 @@ geofences
     <type>Periodic/Polled</type>
     <description>High precision position solution in ECEF</description>
     <comment>See important comments concerning validity of position given in section Navigation Output Filters.</comment>
-    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2 and 20.3</firmware>
     <structure>
       <header>0xB5 0x62</header>
       <class>0x01</class>
@@ -16660,7 +17933,7 @@ coordinate. Must be in the range of -99..
     <type>Periodic/Polled</type>
     <description>High precision geodetic position solution</description>
     <comment>See important comments concerning validity of position given in section Navigation Output Filters. This message outputs the Geodetic position with high precision in the currently selected ellipsoid. The default is the WGS84 Ellipsoid, but can be changed with the message UBX-CFG-DAT.</comment>
-    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2, 20.3, 22, 22.01, 23 and 23.01</firmware>
+    <firmware>Supported on: u-blox 8 / u-blox M8 protocol versions 20.01, 20.1, 20.2 and 20.3</firmware>
     <structure>
       <header>0xB5 0x62</header>
       <class>0x01</class>
@@ -16900,7 +18173,7 @@ flags.</comment>
               <index>2</index>
               <type>unsigned value</type>
               <name>totRangeGPS</name>
-              <description>1 = Data reference ToW out of range.</description>
+              <description>1 = Data reference TOW out of range.</description>
             </type>
             <type>
               <index>3</index>
@@ -16976,7 +18249,7 @@ information flags.</comment>
               <index>2</index>
               <type>unsigned value</type>
               <name>totRangeGAL</name>
-              <description>1 = Data reference ToW out of range.</description>
+              <description>1 = Data reference TOW out of range.</description>
             </type>
             <type>
               <index>3</index>
@@ -17052,7 +18325,7 @@ information flags.</comment>
               <index>2</index>
               <type>unsigned value</type>
               <name>totRangeBDS</name>
-              <description>1 = Data reference ToW out of range.</description>
+              <description>1 = Data reference TOW out of range.</description>
             </type>
             <type>
               <index>3</index>
@@ -19073,10 +20346,10 @@ output</comment>
 1: No spoofing indicated
 2: Spoofing indicated
 3: Multiple spoofing indications
-Note that the spoofing state value only reflects the dector state for the current navigation epoch. As
-spoofing can be detected most easily at the transition from real signal to spoofing signal, this is also
-where the detector is triggered the most. I.e. a value of 1 - No spoofing indicated does not mean that
-the receiver is not spoofed, it simply states that the detector was not triggered in this epoch.</description>
+Note that the spoofing state value only reflects the detector state for the current navigation epoch.
+As spoofing can be detected most easily at the transition from real signal to spoofing signal, this is
+also where the detector is triggered the most. I.e. a value of 1 - No spoofing indicated does not mean
+that the receiver is not spoofed, it simply states that the detector was not triggered in this epoch.</description>
             </type>
             <type>
               <index>5</index>


### PR DESCRIPTION
Wanna draw the attention to the fact that some messages might have optional payload ('UBX-AID-ALM'), might have repeated payload ('UBX-CFG-DOSC'), or might hav both ('UBX-ESF-MEAS').

The provided text dump (https://github.com/daedaleanai/ublox/blob/main/ubx/msgdefs.txt) was made for r20 revision, but the pdf on the site has been changed to r21 revision. I've generated xml file for both revisions, each in its own commit.

Some messages have different structure in different versions, in this case there are multiple entries for the same message in xml file ('UBX-CFG-NAVX5', 'UBX-CFG-NMEA').
Some messages might be used to send different commands, in this case there are multiple entries in xml file as well ('UBX-CFG-NMEA', 'UBX-CFG-PRT').


32.17.17 `UBX-NAV-PVT` has `psmState` bit on the image, but it's not listed in description table. It might have the same structure as 32.14.1 `UBX-LOG-BATCH` `psmState` value. I didn't add `psmState` into xml file.

If any changes to the structure of xml file are required, I can make it.